### PR TITLE
Changes the way the modal works to prevent it to show up inadvertently

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -9,12 +9,12 @@ class Modal extends React.Component {
     super(props);
 
     this.state = {
-      open: this.props.isOpen
+      open: this.props.visible
     };
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({ open: nextProps.isOpen });
+    this.setState({ open: nextProps.visible });
   }
 
   close(e) {
@@ -25,7 +25,7 @@ class Modal extends React.Component {
       node = node.parentNode;
     }
 
-    this.setState({ open: false });
+    this.props.onClose();
   }
 
 
@@ -46,7 +46,8 @@ class Modal extends React.Component {
 }
 
 Modal.propTypes = {
-  isOpen: React.PropTypes.bool.isRequired
+  visible: React.PropTypes.bool.isRequired,
+  onClose: React.PropTypes.func.isRequired
 };
 
 export default Modal;

--- a/src/components/Modal/styles.postcss
+++ b/src/components/Modal/styles.postcss
@@ -14,6 +14,7 @@
 
   &.-hidden {
     opacity: 0;
+    pointer-events: none;
   }
 
   > .content {


### PR DESCRIPTION
This PR changes the props of the modal to prevent it to show up inadvertently when its parent component would render again.

@davidsingal @dhakelila, it requires two props:
- `visible`: the initial state of the modal
- `onClose`: a callback which will be called when the user would close the modal

The `onClose` callback should be used such as when it's called, the parent component updates its state to store that the modal is closed. Also, this state should be the one passed as the `visible` prop so the modal would be closed by a re-render of the parent.
