### PR TITLE
Feature/link dashboard stats to api

### DIFF
--- a/src/components/Dashboard/DashSummary.js
+++ b/src/components/Dashboard/DashSummary.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import './dash-summary-styles.postcss';
+import DashSummaryModel from './DashSummaryModel';
 import React from 'react';
 
 class DashSummary extends React.Component {
@@ -9,15 +10,27 @@ class DashSummary extends React.Component {
     super(props);
     this.props = props;
     this.state = {
-      totalDonations: '19,823,743',
-      donationsAmount: '10,645,846',
-      totalCampaigns: '562,430'
+      totalDonations: null,
+      donationsAmount: null
     };
+  }
+
+  componentDidMount() {
+    this.state = new DashSummaryModel();
+
+    this.state.fetch({
+    })
+    .done((result) => {
+      this.setState({
+        totalDonations: result.total_donations,
+        donationsAmount: result.total_funds
+      });
+    });
   }
 
   render() {
     return (
-      <div className="m-dash-summary">  
+      <div className="m-dash-summary">
         <div className="summary-item">
           <p className="text text-legend-title">Donations </p>
           <span className="number number-l">{ this.state.totalDonations }</span>

--- a/src/components/Dashboard/DashSummary.js
+++ b/src/components/Dashboard/DashSummary.js
@@ -2,6 +2,7 @@
 
 import './dash-summary-styles.postcss';
 import DashSummaryModel from './DashSummaryModel';
+import FiltersModel from '../../scripts/models/filtersModel';
 import React from 'react';
 
 class DashSummary extends React.Component {
@@ -16,10 +17,8 @@ class DashSummary extends React.Component {
   }
 
   componentDidMount() {
-    this.state = new DashSummaryModel();
-
-    this.state.fetch({
-    })
+    this.dashSummary = new DashSummaryModel();
+    this.dashSummary.fetch({})
     .done((result) => {
       this.setState({
         totalDonations: result.total_donations,
@@ -37,7 +36,7 @@ class DashSummary extends React.Component {
         </div>
         <div className="summary-item">
           <p className="text text-legend-s">Amount donated </p>
-          <span className="number number-m"> $ { this.state.donationsAmount }</span>
+          <span className="number number-m"> ${ this.state.donationsAmount }</span>
         </div>
       </div>
     )

--- a/src/components/Dashboard/DashSummaryModel.js
+++ b/src/components/Dashboard/DashSummaryModel.js
@@ -1,0 +1,13 @@
+'use strict';
+
+import Backbone from 'backbone';
+
+class DashSummaryModel extends Backbone.Model {
+
+
+  url() {
+    return `${config.apiUrl}/statistics`
+  }
+}
+
+export default DashSummaryModel;

--- a/src/scripts/models/DonorModel.js
+++ b/src/scripts/models/DonorModel.js
@@ -7,7 +7,7 @@ class DonorModel extends CartodbModel {
   constructor(options) {
     super(options);
     const settings = {
-      table: 'care_donors',
+      table: 'donors',
       query: 'iso=\'USA\''
     }
     this.options = Object.assign(this.defaults, settings);


### PR DESCRIPTION
This PR sets an initial link between the dashboard statistics and the api statistics endpoint.

It still doesn't update when the filters are changed, but I think we should merge anyway.
