### PR TITLE
Updates the summary of the dashboard when the filters or the timeline update

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -230,7 +230,7 @@ class App extends React.Component {
     ];
 
     return (
-      <div className="l-app is-loading">
+      <div className="l-app">
 
         <div id="map" className="l-map" ref="Map"></div>
 

--- a/src/components/Dashboard/DashSummary.js
+++ b/src/components/Dashboard/DashSummary.js
@@ -16,8 +16,7 @@ class DashSummary extends React.Component {
     this.props = props;
     this.state = {
       totalDonations: null,
-      donationsAmount: null,
-      isLoading: false
+      donationsAmount: null
     };
   }
 
@@ -28,8 +27,7 @@ class DashSummary extends React.Component {
 
   shouldComponentUpdate(nextState) {
     if(this.state.totalDonations !== nextState.totalDonations ||
-      this.state.donationsAmount !== nextState.donationsAmount ||
-      this.state.isLoading !== nextState.isLoading) {
+      this.state.donationsAmount !== nextState.donationsAmount) {
       return true;
     }
     return false;
@@ -53,7 +51,7 @@ class DashSummary extends React.Component {
 
   render() {
     return (
-      <div className={ 'm-dash-summary ' + (this.state.isLoading ? 'is-loading -small' : '') }>
+      <div className="m-dash-summary">
         <div className="summary-item">
           <p className="text text-legend-title">Donations </p>
           <span className="number number-l">{ utils.numberNotation(this.state.totalDonations) }</span>
@@ -76,13 +74,11 @@ DashSummary.prototype.fetchData = (function() {
     if(state.sectors && state.sectors.length) params.sectors_slug = state.sectors;
     if(state.region) params.countries_iso = [ state.region ];
 
-    this.setState({ isLoading: true });
     this.dashSummary.fetch({ data: params })
       .done(res => {
         this.setState({
           totalDonations: res.total_donations,
-          donationsAmount: res.total_funds,
-          isLoading: false
+          donationsAmount: res.total_funds
         });
       });
   }, 500);

--- a/src/components/Dashboard/DashSummary.js
+++ b/src/components/Dashboard/DashSummary.js
@@ -16,7 +16,8 @@ class DashSummary extends React.Component {
     this.props = props;
     this.state = {
       totalDonations: null,
-      donationsAmount: null
+      donationsAmount: null,
+      isLoading: false
     };
   }
 
@@ -27,14 +28,15 @@ class DashSummary extends React.Component {
 
   shouldComponentUpdate(nextState) {
     if(this.state.totalDonations !== nextState.totalDonations ||
-      this.state.donationsAmount !== nextState.donationsAmount) {
+      this.state.donationsAmount !== nextState.donationsAmount ||
+      this.state.isLoading !== nextState.isLoading) {
       return true;
     }
     return false;
   }
 
   componentWillReceiveProps(nextProps) {
-    const startDate = nextProps.filters && nextProps.filters.from;
+    const startDate = nextProps.timeline && nextProps.timeline.from || nextProps.filters && nextProps.filters.from;
     const endDate = nextProps.timeline && nextProps.timeline.to || nextProps.filters && nextProps.filters.to;
     const sectors = nextProps.filters && nextProps.filters.sectors || [];
     const region = nextProps.filters && nextProps.filters.region;
@@ -51,7 +53,7 @@ class DashSummary extends React.Component {
 
   render() {
     return (
-      <div className="m-dash-summary">
+      <div className={ 'm-dash-summary ' + (this.state.isLoading ? 'is-loading -small' : '') }>
         <div className="summary-item">
           <p className="text text-legend-title">Donations </p>
           <span className="number number-l">{ utils.numberNotation(this.state.totalDonations) }</span>
@@ -71,14 +73,16 @@ DashSummary.prototype.fetchData = (function() {
 
     if(state.startDate) params.start_date = moment(state.startDate).format('YYYY-MM-DD');
     if(state.endDate) params.end_date = moment(state.endDate).format('YYYY-MM-DD');
-    if(state.sectors && state.sectors.length) params.sectors = state.sectors;
+    if(state.sectors && state.sectors.length) params.sectors_slug = state.sectors;
     if(state.region) params.countries_iso = [ state.region ];
 
+    this.setState({ isLoading: true });
     this.dashSummary.fetch({ data: params })
       .done(res => {
         this.setState({
           totalDonations: res.total_donations,
-          donationsAmount: res.total_funds
+          donationsAmount: res.total_funds,
+          isLoading: false
         });
       });
   }, 500);

--- a/src/components/Dashboard/DashSummary.js
+++ b/src/components/Dashboard/DashSummary.js
@@ -4,6 +4,8 @@ import './dash-summary-styles.postcss';
 import DashSummaryModel from './DashSummaryModel';
 import FiltersModel from '../../scripts/models/filtersModel';
 import React from 'react';
+import _ from 'underscore';
+import moment from 'moment';
 
 import utils from '../../scripts/helpers/utils';
 
@@ -20,13 +22,31 @@ class DashSummary extends React.Component {
 
   componentDidMount() {
     this.dashSummary = new DashSummaryModel();
-    this.dashSummary.fetch({})
-    .done((result) => {
-      this.setState({
-        totalDonations: result.total_donations,
-        donationsAmount: result.total_funds
-      });
-    });
+    this.fetchData(this.state);
+  }
+
+  shouldComponentUpdate(nextState) {
+    if(this.state.totalDonations !== nextState.totalDonations ||
+      this.state.donationsAmount !== nextState.donationsAmount) {
+      return true;
+    }
+    return false;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const startDate = nextProps.filters && nextProps.filters.from;
+    const endDate = nextProps.timeline && nextProps.timeline.to || nextProps.filters && nextProps.filters.to;
+    const sectors = nextProps.filters && nextProps.filters.sectors || [];
+    const region = nextProps.filters && nextProps.filters.region;
+
+    if(this.state.startDate !== startDate || this.state.endDate !== endDate ||
+      !this.state.sectors && sectors ||
+      this.state.sectors.toString() !== sectors.toString() ||
+      this.state.region !== region) {
+      this.fetchData({ startDate, endDate, sectors, region });
+    }
+
+    this.setState({ startDate, endDate, sectors, region });
   }
 
   render() {
@@ -44,5 +64,24 @@ class DashSummary extends React.Component {
     )
   }
 }
+
+DashSummary.prototype.fetchData = (function() {
+  return _.throttle(function(state) {
+    const params = {};
+
+    if(state.startDate) params.start_date = moment(state.startDate).format('YYYY-MM-DD');
+    if(state.endDate) params.end_date = moment(state.endDate).format('YYYY-MM-DD');
+    if(state.sectors && state.sectors.length) params.sectors = state.sectors;
+    if(state.region) params.countries_iso = [ state.region ];
+
+    this.dashSummary.fetch({ data: params })
+      .done(res => {
+        this.setState({
+          totalDonations: res.total_donations,
+          donationsAmount: res.total_funds
+        });
+      });
+  }, 500);
+})();
 
 export default DashSummary;

--- a/src/components/Dashboard/dash-summary-styles.postcss
+++ b/src/components/Dashboard/dash-summary-styles.postcss
@@ -3,6 +3,7 @@
 .m-dash-summary {
   padding: rem(15) 0 rem(25);
   border-bottom: 1px solid $color-7;
+  position: relative;
 
  .summary-item {
     width: 100%;

--- a/src/components/Dashboard/dash-summary-styles.postcss
+++ b/src/components/Dashboard/dash-summary-styles.postcss
@@ -3,7 +3,7 @@
 .m-dash-summary {
   padding: rem(15) 0 rem(25);
   border-bottom: 1px solid $color-7;
-  
+
  .summary-item {
     width: 100%;
     display: flex;

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -45,7 +45,7 @@ class Dashboard extends React.Component {
                       currentMode = { this.props.currentMode }
                       changeModeFn = { this.props.changeModeFn }
                     />
-                    
+
       tabsMobile = null;
     }
 
@@ -103,7 +103,8 @@ class Dashboard extends React.Component {
                 regions={ this.props.regions }
               />
               <DashSummary
-                currentMode = { this.props.currentMode }
+                filters={ this.props.filters }
+                timeline={ this.props.timelineDates }
               />
               { layersSwitcher }
             </div>

--- a/src/styles/helpers.postcss
+++ b/src/styles/helpers.postcss
@@ -97,7 +97,7 @@
     position: absolute;
     top: 50%;
     left: 50%;
-    margin: -($size/2) 0 0 -($size/2);
+    margin: calc(-1 * $size / 2 - $border-width) 0 0 calc(-1 * $size / 2);
     transition: all .75s ease 0s;
     border-radius: 100%;
     border-top: $border-width solid $color2;

--- a/src/styles/states.postcss
+++ b/src/styles/states.postcss
@@ -5,8 +5,8 @@
 
 .is-loading {
   @mixin spinner rem(40), rem(5), $color-1, $color-2;
-}
 
-.is-loading.-small {
-  @mixin spinner rem(30), rem(5), $color-1;
+  &.-small {
+    @mixin spinner rem(30), rem(5), $color-1, $color-2;
+  }
 }


### PR DESCRIPTION
This PR updates the figures of the dashboard's summary whenever the filters update or the timeline's handle is moved.

@simaob It seems that the request to `/api/v1/statistics` always return the same values. Could you check if there's an issue on your part or if something is wrong with our queries?
