### PR TITLE
Bug/torque layer

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -209,6 +209,15 @@ class App extends React.Component {
       if (this.router.params.attributes.layer) {
         this._updateLayersCollection(this.router.params.attributes.layer);
       }
+      const currentMode = this.state.mode;
+
+      /* Absolutely necessary if we want the map to load when the app is loaded
+       * without any param */
+      this.timeline.changeMode(currentMode,
+        this.state.dataInterval[currentMode],
+        this.state.ranges[currentMode],
+        true); /* We assume that the layer by default is a Torque one */
+
       this.setState({ 'ready': true });
       this.initMap();
     })
@@ -380,12 +389,6 @@ class App extends React.Component {
   }
 
   _updateLayersCollection(layer) {
-    const currentMode = this.state.mode;
-    this.timeline.changeMode(currentMode,
-      this.state.dataInterval[currentMode],
-      this.state.ranges[currentMode],
-      /torque/gi.test(layer));
-
     // Inactive all layers of the same group
     let cogroupLayers = layersCollection.filter(model => model.attributes.category === this.state.mode);
     _.each(cogroupLayers, (activeLayer) => {

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -187,15 +187,26 @@ class MapView extends Backbone.View {
           this.currentLayer = newLayer;
           this.currentLayerConfig = layerConfig;
 
-          /* Hack because torque doesn't provide a working event "load" or
-           * "done" */
           if(this.currentLayerConfig.layer_type === 'torque') {
-            setTimeout(() => this.changeLayerTimeline(), 3000);
+            this.initTorqueLayer();
           }
         }
       });
       this.state.set('currentLayer', activeLayer.get('slug'));
     });
+  }
+
+  /* Hack to get to know when a torque layer has been loaded as there's no
+   * proper "loaded" working event in the torque library */
+  initTorqueLayer() {
+    const callback = () => {
+      const isReady = !Number.isNaN(this.currentLayer.layer.timeToStep(new Date()));
+      if(isReady) {
+        clearTimeout(timeout);
+        this.changeLayerTimeline();
+      }
+    };
+    const timeout = setInterval(callback.bind(this), 200);
   }
 
   _removeCurrentLayer() {

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -423,7 +423,7 @@ class TimelineView extends Backbone.View {
 TimelineView.prototype.triggerCursorDate = (function() {
   let oldEndDate = null;
 
-  return function(endDate) {
+  return _.throttle(function(endDate) {
     if(+oldEndDate === +endDate) return;
 
     const startDate  = moment(this.scale.domain()[0]).add(1, 'days').toDate();
@@ -433,7 +433,7 @@ TimelineView.prototype.triggerCursorDate = (function() {
     });
 
     oldEndDate = endDate;
-  };
+  }, 20);
 
 })();
 


### PR DESCRIPTION
This PR brings several improvements and critical fixes, mainly in relation with the Torque layer.
- It throttles the updates of the dashboard's dates to "only" repaint it every 20ms (at 50 FPS rate).
- It fixes an issue where the Torque layer would not load on a page load when the URL would not contain any param.
- It makes the Torque layer more reliable and quicker using a custom hack to check when it's been loaded (check every 200ms i.e. 5 FPS).
