### PR TITLE
fixing projects layer first load

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -114,7 +114,7 @@ class App extends React.Component {
   }
 
   _updateRouterParams() {
-    /* Here we update general state with roouter params and our device check. */
+    /* Here we update general state with router params and our device check. */
     const newParams = _.extend({}, { donation: this.router.params.attributes.donation && true }, this.router.params.attributes);
     this.setState(newParams);
   }
@@ -189,7 +189,6 @@ class App extends React.Component {
 
   onRouterChangeMap() {
     const params = this.router.params.toJSON();
-
 
     if (params.zoom) {
       this.mapView.state.set({zoom: params.zoom})
@@ -377,8 +376,8 @@ class App extends React.Component {
     this.router.update({mode: mode, layer: activeLayer});
     this.setState({ mode: mode, layer: activeLayer });
 
-    this.mapView.state.set({ 'mode': mode });
     this.timeline.changeMode(mode, this.state.dataInterval[mode], this.state.ranges[mode]);
+    this.mapView.state.set({ 'mode': mode, 'layer': activeLayer, 'currentLayer': activeLayer });
   }
 
   changeLayer(layer, e) {

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -75,13 +75,16 @@ class MapView extends Backbone.View {
   }
 
   _createMap() {
+
     const mapOptions = {
       zoom: this.state.attributes.zoom,
       center: [this.state.attributes.lat, this.state.attributes.lng],
-      tileLayer: {
-        continuousWorld: false,
-        noWrap: true
-      }
+      //TODO: avoid torque and other layers repeat;
+      // minZoom: 2,
+      // tileLayer: {
+      //   continuousWorld: false,
+      //   noWrap: true,
+      // }
     };
     this.map = L.mapbox.map(this.el, this.options.style, mapOptions);
 
@@ -116,7 +119,8 @@ class MapView extends Backbone.View {
     });
 
     this.state.on('change:filters', () => this.changeLayer());
-    this.state.on('change:timelineDates', () => this.changeLayerTimeline());
+    this.state.on('change:timelineDates', () => this.changeLayerTimelineTorque());
+    this.state.on('change:timelineDates', () => this.changeLayerTile());
 
     this.state.on('change:mode', _.bind(this.changeLayer, this));
     layersCollection.on('change', _.bind(this.changeLayer, this));
@@ -203,7 +207,7 @@ class MapView extends Backbone.View {
       const isReady = !Number.isNaN(this.currentLayer.layer.timeToStep(new Date()));
       if(isReady) {
         clearTimeout(timeout);
-        this.changeLayerTimeline();
+        this.changeLayerTimelineTorque();
       }
     };
     const timeout = setInterval(callback.bind(this), 200);
@@ -220,9 +224,14 @@ class MapView extends Backbone.View {
     this._addLayer();
   }
 
+  changeLayerTile() {
+    if (this.state.toJSON().mode === 'projects') {
+      this._addLayer();
+    }
+  }
 };
 
-MapView.prototype.changeLayerTimeline = (function() {
+MapView.prototype.changeLayerTimelineTorque = (function() {
 
   const addLayer = _.throttle(function() {
     this._addLayer();


### PR DESCRIPTION
This PR fixes a minnor issue when trying to load "projects" layer the very first time. 

When we arrived to the map for the first time without any data at the url, and we changed to projects mode, we updated the correct date range for projects, but due to an asynchronism issue, the new (and correct) date arrived after the "project" layer was load giving us an incorrect visualisation. 

This should be fixed now. 
