### PR TITLE
fixed data range to not crash into different time zones

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -59,7 +59,7 @@ class App extends React.Component {
       /* Ranges for which we have data */
       ranges: {
         donations: [ new Date('2011-07-01'), new Date() ],
-        projects:  [ new Date('2012-01-01'), new Date('2015-01-01') ]
+        projects:  [ new Date('2012-01-01'), new Date('2015-01-02') ]
       },
       /* Specify how often we should update the map when playing the timeline
        * or moving the handle. Dates are rounded "nicely" to the interval. */


### PR DESCRIPTION
This PR fixes a little but important issue with dates. 
We are setting date ranges for timeline with new Date() object, who gives us a local date. 
We had this as project range:
`projects:  [ new Date('2012-01-01'), new Date('2015-01-01') ]`

The problem is that for different time zones, new Date('2015-01-01') didn't return the expected date and gave us the year 2014 instead of 2014.

I temporary fixed the issue setting that range to: 
`projects:  [ new Date('2012-01-01'), new Date('2015-01-02') ]`

To be sure that we always get the year 2015 in projects layer. We don't need day-precision in project layer, so this fix solves our problem before we will check how to implement UTC hours without crashing anything.
