### PR TITLE
Bug/cursor restoring position

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -417,7 +417,7 @@ class App extends React.Component {
   updateMapDates(dates) {
     this.setState({ mapDates: dates });
     //MAP STATE CHANGE
-    this.mapView.state.set({ timelineDates: dates });
+    if(this.mapView) this.mapView.state.set({ timelineDates: dates });
   }
 
   setDonationsAsmode() {

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -258,19 +258,23 @@ class App extends React.Component {
 
   // TIMELINE METHODS
   initTimeline() {
-    const wholeRange = [
+    /* We define the domain of the timeline */
+    let domain = [
       new Date(Math.min(this.state.ranges.donations[0], this.state.ranges.projects[0])),
       new Date(Math.max(this.state.ranges.donations[1], this.state.ranges.projects[1]))
     ];
+    if(this.state.filters.from || this.state.filters.to) {
+      domain = [ this.state.filters.from, this.state.filters.to ];
+    }
 
     const timelineParams = {
       el: this.refs.Timeline,
-      domain: wholeRange,
+      domain: domain,
       interval: this.state.dataInterval[this.state.mode],
       filters: this.state.filters,
       triggerTimelineDates: this.updateTimelineDates.bind(this),
       triggerMapDates: this.updateMapDates.bind(this),
-      ticksAtExtremities: false
+      ticksAtExtremities: this.state.filters.from || this.state.filters.to
     };
 
     /* We retrieve the position of the cursor from the URL if exists */
@@ -282,13 +286,6 @@ class App extends React.Component {
     }
 
     this.timeline = new TimelineView(timelineParams);
-
-    /* On init, we need to show only the range passed as argument */
-    const interval = this.state.dataInterval[this.state.mode];
-    if(this.state.filters.from || this.state.filters.to) {
-      const range = [ this.state.filters.from, this.state.filters.to ];
-      this.timeline.setRange(range, interval, true);
-    }
   }
 
   // MAP METHODS

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -384,8 +384,10 @@ class TimelineView extends Backbone.View {
 
     if(this.cursorPosition < dataRange[0]) {
       this.cursorPosition = dataRange[0];
+      this.triggerCursorDate(this.cursorPosition);
     } else if(this.cursorPosition > dataRange[1]) {
       this.cursorPosition = dataRange[1];
+      this.triggerCursorDate(this.cursorPosition);
     }
 
     /* We force some params for the speed of the timeline and frequency of the


### PR DESCRIPTION
This PR fixes three issues:
- an error could appear in the console because the timeline would "tell" to the map to update whereas the it wouldn't be instantiated yet
- the cursor's position could not take into account the date in the URL in case date filters would be set
- in the URL, the timeline's date wouldn't be updated when switching from donations to projects (which forces the cursor to automatically move to the last date with data when outside of the range)

Additionally, it reduces the number of re-render of the timeline by 1 💪🏼.
