### PR TITLE
Center map when clicking showing a pop-up

### DIFF
--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -135,11 +135,11 @@ class MapView extends Backbone.View {
     this.map.on('dragend', _.bind(this._setStatePosition, this));
   }
 
-  _setStateZoom(e) {
+  _setStateZoom() {
     this.state.set({zoom: this.map.getZoom()});
   }
 
-  _setStatePosition(e) {
+  _setStatePosition() {
     const position = this.map.getCenter();
     this.state.set({ lat: position.lat, lng: position.lng });
   }

--- a/src/components/PopUp/PopUp.js
+++ b/src/components/PopUp/PopUp.js
@@ -48,6 +48,10 @@ class PopUp extends Backbone.View {
     this.options.map.closePopup();
   }
 
+  _panMap() {
+    this.options.map.panTo(this.options.latLng);
+  }
+
   _drawPopUp() {
     this.popUp = L.popup({closeButton: false})
       .setLatLng(this.options.latLng)
@@ -56,6 +60,7 @@ class PopUp extends Backbone.View {
 
     this.setEvents();
     this._setEventsModal();
+    this._panMap();
   }
 
   setEvents() {


### PR DESCRIPTION
Added feature to center the map when showing a tooltip. To avoid it stay under another elements like dashboard and make imposible to interact with close btn

The thing is that the animation is not awesome and when we are too far from the center, it could be confusing for user orientation... Let see what Elena thinks about.
