### PR TITLE
Feature/global refactor

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -463,7 +463,7 @@ class App extends React.Component {
           filters={ this.state.filters }
           sectors={ this.state.sectors }
           regions={ this.state.regions }
-          dateRange={ this.state.ranges[this.state.mode] }
+          domain={ this.state.layer.domain }
           timelineDates={ this.state.timelineDates }
           timelineDate={ this.state.timelineDate }
         />

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -295,6 +295,9 @@ class App extends React.Component {
 
   // MAP METHODS
   initMap() {
+    /* We assume that the state already took into account the params from the
+     * router. By doing that line, we ensure we have default values in the URL.
+     */
     this.router.update({
       mode: this.state.mode,
       layer: this.state.layer

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -376,13 +376,14 @@ class App extends React.Component {
     this.router.update({mode: mode, layer: layer.toJSON().slug});
     this.setState({ mode: mode, layer: layer.toJSON() });
 
-    this.updateTimeline(layer.toJSON());
-
+    /* We should always update the map before the timeline */
     this.mapView.state.set({
       mode,
       layer: layer.toJSON().slug,
       currentLayer: layer.toJSON().slug
     });
+
+    this.updateTimeline(layer.toJSON());
   }
 
   changeLayer(layer) {

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -108,6 +108,13 @@ class App extends React.Component {
       }
     }
 
+    /* Update the state of the map */
+    const newMapState = {};
+    if (params.zoom) newMapState.zoom = params.zoom;
+    if (params.lat) newMapState.lat = params.lat;
+    if (params.lng) newMapState.lng = params.lng;
+    this.mapView.state.set(newMapState);
+
     /* Update the filters */
     const newFiltersModel = {};
 
@@ -142,22 +149,6 @@ class App extends React.Component {
     filtersModel.set(newFiltersModel);
   }
 
-  onRouterChangeMap() {
-    const params = this.router.params.toJSON();
-
-    if (params.zoom) {
-      this.mapView.state.set({zoom: params.zoom})
-    }
-
-    if (params.lat) {
-      this.mapView.state.set({lat: params.lat})
-    }
-
-    if (params.lng) {
-      this.mapView.state.set({lng: params.lng})
-    }
-  }
-
   _initData() {
     layersCollection.fetch()
       .done(() => {
@@ -171,9 +162,7 @@ class App extends React.Component {
         this.router = new Router();
         this.router.start();
         this._updateRouterParams();
-        /* TODO: merge these two methods */
         this.router.params.on('change', this.onRouterChange.bind(this));
-        this.router.params.on('change', this.onRouterChangeMap.bind(this));
 
         const mode = this.router.params.attributes.mode || this.state.mode;
         const layerSlug = this.router.params.attributes.layer;
@@ -252,7 +241,6 @@ class App extends React.Component {
     if(this.router.params.toJSON().timelineDate) {
       const date = moment.utc(this.router.params.toJSON().timelineDate, 'YYYY-MM-DD');
       if(date.isValid()) {
-        /* TODO: should check that the date is within the domain */
         timelineParams.cursorPosition = date.toDate();
       }
     }

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -486,8 +486,8 @@ class App extends React.Component {
           visible={ this.state.filtersOpen }
           onClose={ this.handleModal.bind(this, 'close', 'filtersOpen') }
           onSave={ this.updateFilters.bind(this) }
-          range={ wholeRange }
-          availableRange={ this.state.ranges[this.state.mode] }
+          wholeDomain={ layersCollection.getDataDomain() }
+          domain={ layersCollection.getActiveLayer(this.state.mode).get('domain') }
           routerParams={ this.router && this.router.params.toJSON() }
         />
 

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -230,7 +230,7 @@ class App extends React.Component {
     const cursor = { speed: layer.timeline.speed };
     const interval = Object.assign({}, layer.timeline.interval);
     interval.unit = d3.time[interval.unit];
-    
+
     let domain = layer.domain.map(date => moment.utc(date).toDate());
     let filters = filtersModel.toJSON();
     if(filters.from && filters.to) {
@@ -245,7 +245,7 @@ class App extends React.Component {
       interval,
       triggerTimelineDates: this.updateTimelineDates.bind(this),
       triggerMapDates: this.updateMapDates.bind(this),
-      ticksAtExtremities: this.state.filters.from || this.state.filters.to
+      ticksAtExtremities: filters.from || filters.to
     };
 
     /* We retrieve the position of the cursor from the URL if exists */
@@ -276,8 +276,7 @@ class App extends React.Component {
     this.timeline.options.domain = domain;
     this.timeline.options.cursor = cursor;
     this.timeline.options.interval = interval;
-    this.timeline.options.ticksAtExtremities = this.state.filters.from ||
-      this.state.filters.to;
+    this.timeline.options.ticksAtExtremities = filters.from || filters.to;
 
     this.timeline.render();
   }
@@ -368,7 +367,7 @@ class App extends React.Component {
     }
   }
 
-  changeMapMode(mode, e) {
+  changeMapMode(mode) {
     const layer = layersCollection.getActiveLayer(mode);
     this.router.update({mode: mode, layer: layer.toJSON().slug});
     this.setState({ mode: mode, layer: layer.toJSON() });
@@ -412,12 +411,13 @@ class App extends React.Component {
   }
 
   setDonationsAsmode() {
-    this.setState({ mode: 'donations' });
+    this.changeMapMode('donations');
   }
 
   resetFilters() {
     filtersModel.clear({ silent: true });
     filtersModel.set(filtersModel.defaults);
+    console.log(filtersModel.toJSON());
   }
 
   handleModal(state, modal) {

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -74,6 +74,7 @@ class App extends React.Component {
      * is instanciated */
     filtersModel.on('change', () => {
       this.setState({ filters: filtersModel.toJSON() });
+      this.updateTimeline(this.state.layer);
       this.router.update(this.parseFiltersForRouter());
     });
 
@@ -254,12 +255,18 @@ class App extends React.Component {
     this.timeline = new TimelineView(timelineParams);
   }
 
-  /* Update the timeline to reflect the attributes of the new layer */
+  /* Update the timeline to reflect the attributes of the new layer and the
+   * filters */
   updateTimeline(layer) {
-    const domain = layer.domain.map(date => moment.utc(date).toDate());
     const cursor = { speed: layer.timeline.speed };
     const interval = Object.assign({}, layer.timeline.interval);
     interval.unit = d3.time[interval.unit];
+
+    let domain = layer.domain.map(date => moment.utc(date).toDate());
+    let filters = filtersModel.toJSON();
+    if(filters.from && filters.to) {
+      domain = [ filters.from, filters.to ];
+    }
 
     this.timeline.options.domain = domain;
     this.timeline.options.cursor = cursor;

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -379,12 +379,16 @@ class App extends React.Component {
   }
 
   changeMapMode(mode, e) {
-    let activeLayer = layersCollection.filter(model => model.attributes.category === mode && model.attributes.active )[0].attributes.slug;
-    this.router.update({mode: mode, layer: activeLayer});
-    this.setState({ mode: mode, layer: activeLayer });
+    const layer = layersCollection.getActiveLayer(mode);
+    this.router.update({mode: mode, layer: layer.toJSON().slug});
+    this.setState({ mode: mode, layer: layer.toJSON() });
 
     this.timeline.changeMode(mode, this.state.dataInterval[mode], this.state.ranges[mode]);
-    this.mapView.state.set({ 'mode': mode, 'layer': activeLayer, 'currentLayer': activeLayer });
+    this.mapView.state.set({
+      mode,
+      layer: layer.toJSON().slug,
+      currentLayer: layer.toJSON().slug
+    });
   }
 
   changeLayer(layer) {

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -57,23 +57,6 @@ class App extends React.Component {
       filters: {},
       sectors: [],
       regions: [],
-      /* Ranges for which we have data */
-      ranges: {
-        donations: [ new Date('2011-07-01'), new Date() ],
-        projects:  [ new Date('2012-01-01'), new Date('2015-01-01') ]
-      },
-      /* Specify how often we should update the map when playing the timeline
-       * or moving the handle. Dates are rounded "nicely" to the interval. */
-      dataInterval: {
-        donations: {
-          unit: d3.time.week.utc,
-          count: 2
-        },
-        projects: {
-          unit: d3.time.year.utc,
-          count: 1
-        }
-      },
       /* The range selected in the timeline */
       timelineDates: {},
       shareOpen: false,
@@ -431,11 +414,6 @@ class App extends React.Component {
   }
 
   render() {
-    const wholeRange = [
-      new Date(Math.min(this.state.ranges.donations[0], this.state.ranges.projects[0])),
-      new Date(Math.max(this.state.ranges.donations[1], this.state.ranges.projects[1]))
-    ];
-
     let content = '';
     if(this.state.ready) {
       content = <div>
@@ -502,7 +480,7 @@ class App extends React.Component {
           filters={ this.state.filters }
           filtersOpen ={ this.state.filtersOpen }
           currentMode={ this.state.mode }
-          dateRange={ this.state.ranges[this.state.mode] }
+          domain={ this.state.layer.domain }
           timelineDates={ this.state.timelineDates }
           onChangeFilters={ this.handleModal.bind(this, 'open', 'filtersOpen') }
           onGoBack={ this.setDonationsAsmode.bind(this) }

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -429,12 +429,9 @@ class App extends React.Component {
       new Date(Math.max(this.state.ranges.donations[1], this.state.ranges.projects[1]))
     ];
 
-    let content = <div className="l-app is-loading">
-      { !sessionStorage.getItem('session') && !this.state.donation ? <Landing /> : '' }
-    </div>;
-
+    let content = '';
     if(this.state.ready) {
-      content = <div className="l-app">
+      content = <div>
 
         <div id="map" className="l-map" ref="Map"></div>
 
@@ -513,15 +510,13 @@ class App extends React.Component {
         <a href="https://my.care.org/site/Donation2;jsessionid=5FED4A2DADFB975A2EDA92B59231B64B.app314a?df_id=20646&mfc_pref=T&20646.donation=form1" rel="noreferrer" target="_blank" id="donate" className="l-donate btn-contrast">
           Donate
         </a>
-
-        { !sessionStorage.getItem('session') && !this.state.donation ? <Landing /> : '' }
       </div>;
     }
 
     return (
       <div className={ 'l-app ' + (this.state.ready ? '' : 'is-loading') }>
         { content }
-        { !sessionStorage.getItem('session') && !this.state.donation ? <Landing /> : '' }
+        { !localStorage.getItem('session') && !this.state.donation ? <Landing /> : '' }
       </div>
     );
   }

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -281,11 +281,12 @@ class App extends React.Component {
 
     const state = this.router.params.toJSON();
     state.timelineDates = this.state.mapDates;
+    state.mode = this.state.mode;
+    state.layer = this.state.layer.slug;
 
     this.mapView = new MapView({
       el: this.refs.Map,
       state,
-      donation: this.state.donation,
       mode: this.state.mode
     });
 
@@ -363,8 +364,7 @@ class App extends React.Component {
     /* We should always update the map before the timeline */
     this.mapView.state.set({
       mode,
-      layer: layer.toJSON().slug,
-      currentLayer: layer.toJSON().slug
+      layer: layer.toJSON().slug
     });
 
     this.updateTimeline(layer.toJSON());
@@ -374,6 +374,7 @@ class App extends React.Component {
     this.router.update({ layer: layer.slug });
     this.setState({ layer });
     layersCollection.setActiveLayer(this.state.mode, layer.slug);
+    this.mapView.state.set({ layer: layer.slug });
     this.updateTimeline(layer);
   }
 
@@ -405,7 +406,6 @@ class App extends React.Component {
   resetFilters() {
     filtersModel.clear({ silent: true });
     filtersModel.set(filtersModel.defaults);
-    console.log(filtersModel.toJSON());
   }
 
   handleModal(state, modal) {

--- a/src/components/Dashboard/DashDates.js
+++ b/src/components/Dashboard/DashDates.js
@@ -27,8 +27,8 @@ class DashboardDates extends React.Component {
       ];
     } else {
       dates = [
-        moment.utc(this.props.dateRange[0]).format('MM·DD·YYYY'),
-        moment.utc(this.props.dateRange[1]).format('MM·DD·YYYY')
+        moment.utc(this.props.domain[0]).format('MM·DD·YYYY'),
+        moment.utc(this.props.domain[1]).format('MM·DD·YYYY')
       ];
     }
 

--- a/src/components/Dashboard/DashLayerSwitcher.js
+++ b/src/components/Dashboard/DashLayerSwitcher.js
@@ -12,9 +12,6 @@ class DashLayerSwitcher extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = {};
-
-    this.firstRender = true;
   }
 
   componentDidMount() {
@@ -26,13 +23,8 @@ class DashLayerSwitcher extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-
-    if(layersCollection.length > 0 && this.firstRender) {
-      this.firstRender = false;
-      return true;
-    } else {
-      return this.props.currentLayer !== nextProps.currentLayer || this.props.currentMode !== nextProps.currentMode;
-    }
+    return this.props.currentMode !== nextProps.currentMode ||
+      this.props.currentLayer != nextProps.currentLayer;
   }
 
   _toogleLegend() {

--- a/src/components/Dashboard/DashLayerSwitcher.js
+++ b/src/components/Dashboard/DashLayerSwitcher.js
@@ -60,7 +60,7 @@ class DashLayerSwitcher extends React.Component {
               <input
                 type ="radio" name="mapMode" checked={ layer.active }
                 id = { layer.slug }
-                onChange = { this.props.changeLayerFn.bind(null, layer.slug) }
+                onChange = { this.props.changeLayerFn.bind(null, layer) }
               />
               <span></span>
               <label htmlFor={ layer.slug } className="text text-legend">{ layer.name }</label>

--- a/src/components/Dashboard/DashSummary.js
+++ b/src/components/Dashboard/DashSummary.js
@@ -38,8 +38,8 @@ class DashSummary extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const startDate = nextProps.timeline && nextProps.timeline.from || nextProps.filters && nextProps.filters.from;
-    const endDate = nextProps.timelineDate || nextProps.timeline && nextProps.timeline.to || nextProps.filters && nextProps.filters.to;
+    const startDate = nextProps.timeline && nextProps.timeline.from || nextProps.filters && nextProps.filters.from || nextProps.domain[0];
+    const endDate = nextProps.timelineDate || nextProps.timeline && nextProps.timeline.to || nextProps.filters && nextProps.filters.to || nextProps.domain[1];
     const sectors = nextProps.filters && nextProps.filters.sectors || [];
     const region = nextProps.filters && nextProps.filters.region;
 

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -93,7 +93,7 @@ class Dashboard extends React.Component {
               <DashDates
                 filters={ this.props.filters }
                 timelineDates={ this.props.timelineDates }
-                dateRange={ this.props.dateRange }
+                domain={ this.props.domain }
               />
               <DashFilters
                 filters={ this.props.filters }
@@ -105,6 +105,7 @@ class Dashboard extends React.Component {
                 timeline={ this.props.timelineDates }
                 currentMode = { this.props.currentMode }
                 timelineDate={ this.props.timelineDate }
+                domain={ this.props.domain }
               />
               { layersSwitcher }
             </div>

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -60,7 +60,6 @@ class Dashboard extends React.Component {
     };
 
     layersSwitcher = <DashLayerSwitcher
-              layers = { this.state.layers }
               currentMode = { this.props.currentMode }
               currentLayer = { this.props.currentLayer }
               changeLayerFn= { this.props.changeLayerFn }

--- a/src/components/Filters/index.js
+++ b/src/components/Filters/index.js
@@ -72,13 +72,13 @@ class FiltersView extends Backbone.View {
   }
 
   renderAvailableRange() {
-    const startDate = moment.utc(this.options.availableRange[0]).format('MM·DD·YYYY');
-    const endDate = moment.utc(this.options.availableRange[1]).format('MM·DD·YYYY');
+    const startDate = moment.utc(this.options.domain[0]).format('MM·DD·YYYY');
+    const endDate = moment.utc(this.options.domain[1]).format('MM·DD·YYYY');
     this.availableRange.innerHTML = `Available dates <span>from ${startDate} to ${endDate}</span>`;
   }
 
-  updateAvailableRange(availableRange) {
-    this.options.availableRange = availableRange;
+  updateAvailableRange(domain) {
+    this.options.domain = domain;
     this.renderAvailableRange();
   }
 
@@ -209,8 +209,8 @@ class FiltersView extends Backbone.View {
 
   /* Return an array of the available years for the date filters */
   getYearRange() {
-    const startDate = moment.utc(this.options.dateRange[0]).add(1, 'days');
-    const endDate   = moment.utc(this.options.dateRange[1]);
+    const startDate = moment.utc(this.options.wholeDomain[0]);
+    const endDate   = moment.utc(this.options.wholeDomain[1]);
     return _.range(startDate.year(), endDate.year() + 1);
   }
 

--- a/src/components/Landing/index.js
+++ b/src/components/Landing/index.js
@@ -13,7 +13,7 @@ class Landing extends React.Component {
   }
 
   getStarted() {
-    sessionStorage.setItem('session', true);
+    localStorage.setItem('session', true);
     this.setState({ visible: false });
   }
 

--- a/src/components/Map/TileLayer.js
+++ b/src/components/Map/TileLayer.js
@@ -42,7 +42,7 @@ class CreateTileLayer {
   _getQuery() {
     const filters = this.options.state.filters;
     const timeline = this.options.state.timelineDates;
-    const statements = optionalStatements[this.options.category]
+    const statements = optionalStatements[this.options.category];
     return this.options.sql_template.replace(/\s\$WHERE/g, () => {
       if(filters || timeline) {
         const res = Object.keys(statements).map(name => {

--- a/src/components/Map/TileLayer.js
+++ b/src/components/Map/TileLayer.js
@@ -38,7 +38,6 @@ class CreateTileLayer {
     this.timestamp = +(new Date());
   }
 
-  //TODO - validate date before send query.
   _getQuery() {
     const filters = this.options.state.filters;
     const timeline = this.options.state.timelineDates;

--- a/src/components/Map/TorqueLayer.js
+++ b/src/components/Map/TorqueLayer.js
@@ -74,8 +74,8 @@ class TorqueLayer {
         const res = Object.keys(statements).map(name => {
           const filter = filters[name];
             return statements[name](filters, [
-              moment.utc(this.options.start_date, 'YYYY-MM-DD'),
-              moment.utc(this.options.end_date, 'YYYY-MM-DD')
+              moment.utc(this.options.domain[0], 'YYYY-MM-DD'),
+              moment.utc(this.options.domain[1], 'YYYY-MM-DD')
             ]);
           }).filter(statement => !!statement)
             .join(' AND ');
@@ -90,6 +90,10 @@ class TorqueLayer {
 
   getCartoCSS() {
     return this.options.geo_cartocss;
+  }
+
+  isReady() {
+    return !Number.isNaN(this.layer.timeToStep(new Date()));
   }
 
 }

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -24,7 +24,6 @@ class MapView extends Backbone.View {
     //Checking for device
     this.device = utils.checkDevice();
 
-
     // Setting first state
     this.state = new Backbone.Model(settings.state);
     this.state.attributes = _.extend({}, this.options, this.state.attributes);
@@ -75,7 +74,6 @@ class MapView extends Backbone.View {
   }
 
   _createMap() {
-
     const southWest = L.latLng(-80, 124),
         northEast = L.latLng(80, -124),
         bounds = L.latLngBounds(southWest, northEast);
@@ -123,12 +121,11 @@ class MapView extends Backbone.View {
       this.map.setView(latlng, this.map.getZoom());
     });
 
-    this.state.on('change:filters', () => this.changeLayer());
-    this.state.on('change:timelineDates', () => this.changeLayerTimelineTorque());
-    this.state.on('change:timelineDates', () => this.changeLayerTile());
+    this.state.on('change:filters', () => this.updateLayer());
+    this.state.on('change:timelineDates', () => this.updateLayer());
 
-    this.state.on('change:mode', _.bind(this.changeLayer, this));
-    layersCollection.on('change', _.bind(this.changeLayer, this));
+    this.state.on('change:mode', _.bind(this.updateLayer, this));
+    layersCollection.on('change', _.bind(this.updateLayer, this));
     filtersModel.on('change', _.bind(this._updateFilters, this));
 
     this.map.on('zoomend', _.bind(this._setStateZoom, this));
@@ -170,38 +167,35 @@ class MapView extends Backbone.View {
   }
 
   _addLayer() {
-    // Remove current pop up at beginning
-    if (this.popUp) {
-      this.popUp.closeCurrentPopup();
-    }
+    /* We only want one layer at a time */
+    if(this.creatingLayer) return;
 
-    // I will draw only active layers for each category;
-    const activeLayers = layersCollection.where({
-      active: true,
-      category: this.state.get('mode')
-    });
+    if(this.popUp) this.popUp.closeCurrentPopup();
 
-    _.each(activeLayers, activeLayer => {
-      const layerConfig = activeLayer.attributes;
-      // Selecting kind of layer by layer_type attribute
-      const layerClass = (layerConfig.layer_type === 'torque') ? TorqueLayer : TileLayer;
-      const newLayer = new layerClass(layerConfig, this.state.toJSON());
+    let activeLayer = layersCollection.getActiveLayer(this.state.get('mode'));
+    if(!activeLayer) return;
 
-      newLayer.createLayer().done(() => {
-        /* We ensure to always display the latest tiles */
-        if(!this.currentLayer ||
-          newLayer.timestamp > this.currentLayer.timestamp) {
-          this._removeCurrentLayer();
-          newLayer.addLayer(this.map);
-          this.currentLayer = newLayer;
-          this.currentLayerConfig = layerConfig;
+    const layerConfig = activeLayer.attributes;
+    const layerClass = (layerConfig.layer_type === 'torque') ? TorqueLayer : TileLayer;
+    const newLayer = new layerClass(layerConfig, this.state.toJSON());
 
-          if(this.currentLayerConfig.layer_type === 'torque') {
-            this.initTorqueLayer();
-          }
+    this.creatingLayer = true;
+
+    console.log(activeLayer);
+
+    newLayer.createLayer().done(() => {
+      /* We ensure to always display the latest tiles */
+      if(!this.currentLayer ||
+        newLayer.timestamp > this.currentLayer.timestamp) {
+        newLayer.addLayer(this.map);
+        this.currentLayer = newLayer;
+        this.currentLayerConfig = layerConfig;
+
+        if(this.currentLayerConfig.layer_type === 'torque') {
+          this.initTorqueLayer();
         }
-      });
-      this.state.set('currentLayer', activeLayer.get('slug'));
+      }
+      this.creatingLayer = false;
     });
   }
 
@@ -209,10 +203,10 @@ class MapView extends Backbone.View {
    * proper "loaded" working event in the torque library */
   initTorqueLayer() {
     const callback = () => {
-      const isReady = !Number.isNaN(this.currentLayer.layer.timeToStep(new Date()));
+      const isReady = this.currentLayer.isReady();
       if(isReady) {
         clearTimeout(timeout);
-        this.changeLayerTimelineTorque();
+        this.updateLayer();
       }
     };
     const timeout = setInterval(callback.bind(this), 200);
@@ -225,38 +219,30 @@ class MapView extends Backbone.View {
     }
   }
 
-  changeLayer() {
-    this._addLayer();
-  }
-
-  changeLayerTile() {
-    if (this.state.toJSON().mode === 'projects') {
-      this._addLayer();
-    }
-  }
 };
 
-MapView.prototype.changeLayerTimelineTorque = (function() {
+MapView.prototype.updateLayer = (function() {
 
-  const addLayer = _.throttle(function() {
+  const _addLayer = _.throttle(function() {
+    this._removeCurrentLayer();
     this._addLayer();
   }, 200);
 
   return function() {
-    if (this.currentLayerConfig && this.currentLayerConfig.layer_type &&
-      this.currentLayerConfig.layer_type === 'torque') {
+    const activeLayer = layersCollection.getActiveLayer(this.state.get('mode'));
+    if(!activeLayer) return;
 
+    if(activeLayer.get('layer_type') !== 'torque' ||
+      this.currentLayerConfig.layer_type !== 'torque') {
+      _addLayer.call(this);
+    } else {
       const currentDate = this.state.toJSON().timelineDates &&
         this.state.toJSON().timelineDates.to || this.state.toJSON().filters.to;
-
       const step = Math.round(this.currentLayer.layer.timeToStep(currentDate));
-      // Doc: https://github.com/CartoDB/torque/blob/master/doc/torque_api.md
       this.currentLayer.layer.setStep(step);
-
-    } else {
-      addLayer.call(this);
     }
   };
+
 })();
 
 MapView.prototype.defaults = {

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -181,8 +181,6 @@ class MapView extends Backbone.View {
 
     this.creatingLayer = true;
 
-    console.log(activeLayer);
-
     newLayer.createLayer().done(() => {
       /* We ensure to always display the latest tiles */
       if(!this.currentLayer ||

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -148,7 +148,7 @@ class MapView extends Backbone.View {
   _infowindowSetUp(e) {
     this.popUp = new PopUpContentView({
       currentMode: this.state.get('mode'),
-      currentLayer: this.state.get('currentLayer'),
+      currentLayer: this.state.get('layer'),
       latLng: e.latlng,
       map: this.map,
       zoom: this.state.get('zoom'),

--- a/src/components/ModalFilters/index.js
+++ b/src/components/ModalFilters/index.js
@@ -20,7 +20,8 @@ class ModalFilters extends Modal {
     }
 
     if(nextProps.domain !== this.props.domain) {
-      this.filters.updateAvailableRange(nextProps.domain);
+      const domain = nextProps.domain.map(date => moment.utc(date, 'YYYY-MM-DD').toDate());
+      this.filters.updateAvailableRange(domain);
     }
 
     return false;

--- a/src/components/ModalFilters/index.js
+++ b/src/components/ModalFilters/index.js
@@ -19,13 +19,14 @@ class ModalFilters extends Modal {
       return true;
     }
 
-    if(nextProps.availableRange !== this.props.availableRange) {
-      this.filters.updateAvailableRange(nextProps.availableRange);
+    if(nextProps.domain !== this.props.domain) {
+      this.filters.updateAvailableRange(nextProps.domain);
     }
 
     return false;
   }
 
+  /* TODO: the params should be in app's state at the beginning */
   getInitialFilters() {
     const routerParams = this.props.routerParams;
     if(!routerParams) return {};
@@ -68,8 +69,8 @@ class ModalFilters extends Modal {
       el: this.refs.Filters,
       closeCallback: this.props.onClose.bind(this),
       saveCallback: this.props.onSave.bind(this),
-      dateRange: this.props.range,
-      availableRange: this.props.availableRange,
+      wholeDomain: this.props.wholeDomain,
+      domain: this.props.domain,
       initialFilters: this.getInitialFilters()
     });
   }

--- a/src/components/ModalNoData/index.js
+++ b/src/components/ModalNoData/index.js
@@ -18,7 +18,7 @@ class ModalNoData extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if(!nextProps.filtersOpen && nextProps.filters.from && nextProps.filters.to &&
-      !utils.rangesIntersect(nextProps.domain,
+      !utils.rangesIntersect(nextProps.domain.map(date => moment.utc(date, 'YYYY-MM-DD').toDate()),
         [ nextProps.filters.from, nextProps.filters.to ],
         (a, b) => +a - (+b))
       ) {

--- a/src/components/ModalNoData/index.js
+++ b/src/components/ModalNoData/index.js
@@ -18,7 +18,7 @@ class ModalNoData extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if(!nextProps.filtersOpen && nextProps.filters.from && nextProps.filters.to &&
-      !utils.rangesIntersect(nextProps.dateRange,
+      !utils.rangesIntersect(nextProps.domain,
         [ nextProps.filters.from, nextProps.filters.to ],
         (a, b) => +a - (+b))
       ) {

--- a/src/components/PopUp/PopUpDonation.js
+++ b/src/components/PopUp/PopUpDonation.js
@@ -21,7 +21,7 @@ class PopUpDonation extends PopUp {
       i++;
     }
 
-    return `<span class="title-sector text text-legend-s -light">Three top sectors of interest</span>
+    return `<span class="title-sector text text-legend-s -light">Top issues of interest</span>
             <ul class="sectors-container">
               ${items}
             </ul>`
@@ -36,7 +36,7 @@ class PopUpDonation extends PopUp {
           i++;
         }
 
-        return `<span class="title-sector text text-legend-s -light">Three top countries of interest</span>
+        return `<span class="title-sector text text-legend-s -light">Top countries of interest</span>
                 <ul class="sectors-container">
                   ${items}
                 </ul>`

--- a/src/components/PopUp/PopUpDonation.js
+++ b/src/components/PopUp/PopUpDonation.js
@@ -21,7 +21,7 @@ class PopUpDonation extends PopUp {
       i++;
     }
 
-    return `<span class="title-sector text text-legend-s -light">Top issues of interest</span>
+    return `<span class="title-sector text text-legend-s -light">Top Issues of Interest</span>
             <ul class="sectors-container">
               ${items}
             </ul>`
@@ -36,7 +36,7 @@ class PopUpDonation extends PopUp {
           i++;
         }
 
-        return `<span class="title-sector text text-legend-s -light">Top countries of interest</span>
+        return `<span class="title-sector text text-legend-s -light">Top Countries of Interest</span>
                 <ul class="sectors-container">
                   ${items}
                 </ul>`

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -10,7 +10,6 @@ import utils from '../../scripts/helpers/utils';
 import './styles.postcss';
 
 const defaults = {
-  domain: [new Date(2012, 0, 1), new Date(2015, 0, 1)],
   milestones: [
     // { date: new Date(2012, 3, 15) },
     // { date: new Date(2012, 4, 27) },
@@ -22,9 +21,6 @@ const defaults = {
     right: 15,
     bottom: 0,
     left: 15
-  },
-  cursor: {
-    speed: 10 /* seconds per year */
   },
   ticksAtExtremities: false
 };
@@ -55,7 +51,6 @@ class TimelineView extends Backbone.View {
 
     this.render();
     this.setListeners();
-
   }
 
   setListeners() {
@@ -219,7 +214,7 @@ class TimelineView extends Backbone.View {
       .attr('class', 'cursor')
       .call(this.brush.event);
 
-    this.options.data = this.options.interval.unit.range.apply(null, this.scale.domain().concat(this.options.interval.count))
+    this.options.data = this.options.interval.unit.utc.range.apply(null, this.options.domain.concat(this.options.interval.count))
       .map(date => ({ date }));
 
     this.currentDataIndex = this.getClosestDataIndex(this.cursorPosition);
@@ -373,46 +368,6 @@ class TimelineView extends Backbone.View {
     return this.options.data.length - 1;
   }
 
-  /* Update the range of the timeline and its interval; shows ticks at the
-   * extremities if true */
-  setRange(domain, interval, extremityTicks) {
-    this.options.domain = domain;
-    this.options.ticksAtExtremities = !!extremityTicks;
-    if(interval) this.options.interval = interval;
-    this.setCursorPosition(this.options.domain[1]);
-  }
-
-  changeMode(mode, interval, dataRange, torqueLayer) {
-    this.options.interval = interval;
-
-    if(this.cursorPosition < dataRange[0]) {
-      this.cursorPosition = dataRange[0];
-      this.triggerCursorDate(this.cursorPosition);
-    } else if(this.cursorPosition > dataRange[1]) {
-      this.cursorPosition = dataRange[1];
-      this.triggerCursorDate(this.cursorPosition);
-    }
-
-    /* We force some params for the speed of the timeline and frequency of the
-     * data */
-    if(mode === 'donations') {
-      if(torqueLayer) {
-        this.options.interval.unit = d3.time.week.utc;
-        this.options.cursor.speed = 10;
-      } else {
-        this.options.cursor.speed = 40;
-        this.options.interval.unit = d3.time.month.utc;
-      }
-    } else {
-      this.options.cursor.speed = 10;
-    }
-
-    this.render();
-
-    this.currentDataIndex = this.getClosestDataIndex(this.cursorPosition);
-    this.triggerCurrentData()
-  }
-
   setCursorPosition(date) {
     if(!moment.utc(this.cursorPosition).isSame(date)) {
       this.cursorPosition = date;
@@ -447,7 +402,7 @@ TimelineView.prototype.triggerCursorDate = (function() {
 TimelineView.prototype.triggerCurrentData = (function() {
   const triggerMapDates = _.debounce(function(dates) {
     this.options.triggerMapDates(dates);
-  }, 100);
+  }, 100, true);
 
   return function() {
     const startDate  = moment.utc(this.scale.domain()[0]).add(1, 'days').toDate();

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -221,6 +221,9 @@ class TimelineView extends Backbone.View {
 
     this.options.data = this.options.interval.unit.range.apply(null, this.scale.domain().concat(this.options.interval.count))
       .map(date => ({ date }));
+
+    this.currentDataIndex = this.getClosestDataIndex(this.cursorPosition);
+    this.triggerCurrentData()
   }
 
   togglePlay() {

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -101,7 +101,6 @@ class TimelineView extends Backbone.View {
     this.axis = d3.svg.axis()
       .scale(this.scale)
       .orient('top')
-      /* TODO: should accept non yearly domains */
       .tickValues(ticksDates)
       .tickFormat((d, i) => {
         /* The ticks at the extremities are the whole date and not just the

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -82,6 +82,10 @@ class TimelineView extends Backbone.View {
     const domain = this.options.domain.concat([]);
     domain[0] = moment.utc(domain[0]).clone().subtract(1, 'days').toDate();
 
+    /* We force the cursor to be within the domain */
+    if(+this.cursorPosition > +this.options.domain[1]) this.cursorPosition = this.options.domain[1];
+    if(+this.cursorPosition < +this.options.domain[0]) this.cursorPosition = this.options.domain[0];
+
     this.scale = d3.time.scale.utc()
       .domain(domain)
       .range([0, svgWidth]);

--- a/src/scripts/collections/layersCollection.js
+++ b/src/scripts/collections/layersCollection.js
@@ -63,8 +63,19 @@ class LayersCollection extends Backbone.Collection {
   /* Within the category "mode", set the layer "slug" as active and all the
    * other inactive */
   setActiveLayer(mode, slug) {
-    this.filter(model => model.attributes.category === mode)
-      .forEach(model => model.set('active', model.get('slug') === slug));
+    let specs = this.toJSON();
+    specs.filter(layer => layer.category === mode)
+      .forEach(layer => layer.active = layer.slug === slug);
+    this.set(specs);
+    this.trigger('change');
+  }
+
+  /* Return the active layer for the current mode, if exists */
+  getActiveLayer(mode) {
+    return this.findWhere({
+      active: true,
+      category: mode
+    });
   }
 
 }

--- a/src/scripts/collections/layersCollection.js
+++ b/src/scripts/collections/layersCollection.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import Backbone from 'backbone';
+import moment from 'moment';
 
 class LayersCollection extends Backbone.Collection {
 
@@ -76,6 +77,18 @@ class LayersCollection extends Backbone.Collection {
       active: true,
       category: mode
     });
+  }
+
+  /* Return a range formed by the minimum date contained into the domain
+   * property of the layers and the maximum one */
+  getDataDomain() {
+    return this.toJSON()
+      .map(layer => layer.domain.map(date => moment.utc(date, 'YYYY-MM-DD').toDate()))
+      .reduce((res, domain) => {
+        if(+res[0] > +domain[0]) res[0] = domain[0];
+        if(+res[1] < +domain[1]) res[1] = domain[1];
+        return res;
+      }, [Infinity, -Infinity]);
   }
 
 }

--- a/src/scripts/collections/layersCollection.js
+++ b/src/scripts/collections/layersCollection.js
@@ -8,6 +8,58 @@ class LayersCollection extends Backbone.Collection {
     return `${config.apiUrl}/layers`;
   }
 
+  parse(data) {
+    return data.map(layerSpec => {
+      switch(layerSpec.slug) {
+        case 'amount-of-money':
+          layerSpec.timeline = {
+            speed: 10,
+            interval: {
+              unit: 'week',
+              count: 2
+            }
+          };
+          break;
+        case 'number-of-donors':
+          layerSpec.timeline = {
+            speed: 40,
+            interval: {
+              unit: 'month',
+              count: 1
+            }
+          };
+          break;
+        case 'projects':
+          layerSpec.timeline = {
+            speed: 40,
+            interval: {
+              unit: 'year',
+              count: 1
+            }
+          };
+          break;
+        case 'refugee-assistance':
+          layerSpec.timeline = {
+            speed: 40,
+            interval: {
+              unit: 'year',
+              count: 1
+            }
+          };
+          break;
+      }
+
+      layerSpec.domain = [
+        layerSpec.start_date,
+        layerSpec.end_date
+      ];
+      delete layerSpec.start_date;
+      delete layerSpec.end_date;
+
+      return layerSpec;
+    });
+  }
+
 }
 
 export default new LayersCollection();

--- a/src/scripts/collections/layersCollection.js
+++ b/src/scripts/collections/layersCollection.js
@@ -32,7 +32,7 @@ class LayersCollection extends Backbone.Collection {
           break;
         case 'projects':
           layerSpec.timeline = {
-            speed: 40,
+            speed: 5,
             interval: {
               unit: 'year',
               count: 1
@@ -41,7 +41,7 @@ class LayersCollection extends Backbone.Collection {
           break;
         case 'refugee-assistance':
           layerSpec.timeline = {
-            speed: 40,
+            speed: 5,
             interval: {
               unit: 'year',
               count: 1

--- a/src/scripts/collections/layersCollection.js
+++ b/src/scripts/collections/layersCollection.js
@@ -60,6 +60,13 @@ class LayersCollection extends Backbone.Collection {
     });
   }
 
+  /* Within the category "mode", set the layer "slug" as active and all the
+   * other inactive */
+  setActiveLayer(mode, slug) {
+    this.filter(model => model.attributes.category === mode)
+      .forEach(model => model.set('active', model.get('slug') === slug));
+  }
+
 }
 
 export default new LayersCollection();


### PR DESCRIPTION
This PR is the first of a series of 2 major refactors.

It brings the following improvements:
- It removes several useless (re-)renders by grouping the changes together and waiting for a "ready" state before painting anything.
- It introduces a new loader at the page loading to fetch the layers specifications (described previously as the "ready" state).
- It re-enforces the resilience of the map, of the timeline and of the state coherence when loading the app with URL params.
- It brings back the layer-specific auto-adjusting timeline's feature (the clients will love it).
- It fixes some small issues and edge cases not covered before.

Overall, the code is better more modular and the app quicker to load and interact.

As the changes cover all the components, it'll be good if @simaob (at least) and @dhakelila could review.
