### PR TITLE
bug/firefox-performance

### DIFF
--- a/src/components/Map/TorqueLayer.js
+++ b/src/components/Map/TorqueLayer.js
@@ -2,6 +2,7 @@
 
 import $ from 'jquery';
 import moment from 'moment';
+import utils from '../../scripts/helpers/utils';
 
 const optionalStatements = {
   donations: {
@@ -89,7 +90,14 @@ class TorqueLayer {
   }
 
   getCartoCSS() {
-    return this.options.geo_cartocss;
+    /* FF has some huge performance issues to render the Torque layer with some
+     * properties of the CartoCSS. We then decided to prioritize the rendering
+     * of the layer over it's visual aspect. Removing the multiply blending mode
+     * permits the app to load and work on FF on Windows even if it's visually
+     * not ideal. Until another fix is found, this should stay like that. */
+    return utils.isFF() ?
+      this.options.geo_cartocss.replace('comp-op: multiply;', '') :
+      this.options.geo_cartocss;
   }
 
 }

--- a/src/scripts/helpers/utils.js
+++ b/src/scripts/helpers/utils.js
@@ -18,6 +18,10 @@ function checkDevice() {
   };
 }
 
+function isFF() {
+  return !!navigator.userAgent.match(/firefox/i);
+}
+
 /* Polyfill for the matches DOM API method (IE 9+)
  * Source: http://youmightnotneedjquery.com */
 function matches(el, selector) {
@@ -94,5 +98,6 @@ export default {
   matches,
   pad,
   rangesIntersect,
-  numberNotation
+  numberNotation,
+  isFF
 };


### PR DESCRIPTION
This PR enables Firefox users on Windows to access the app without being notified that a script is blocking the page.

In order to address the performance issue, we had no other choice than remove the multiply blending-mode of the Torque layer. It's a real turn-off, but it's still better to have the app working.
