### PR TITLE
Bug/region filter

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -388,10 +388,6 @@ class App extends React.Component {
     this.setState({ filtersOpen: !this.state.filtersOpen });
   }
 
-  updateFilters(filters) {
-    this.setState({ filters: filters });
-  }
-
   setDonationsAsmode() {
     this.changeMapMode('donations');
   }
@@ -463,7 +459,7 @@ class App extends React.Component {
         <ModalFilters
           visible={ this.state.filtersOpen }
           onClose={ this.handleModal.bind(this, 'close', 'filtersOpen') }
-          onSave={ this.updateFilters.bind(this) }
+          onSave={ () => {} }
           wholeDomain={ layersCollection.getDataDomain() }
           domain={ this.state.layer.domain }
           routerParams={ this.router && this.router.params.toJSON() }

--- a/src/components/Dashboard/dash-filters-styles.postcss
+++ b/src/components/Dashboard/dash-filters-styles.postcss
@@ -3,7 +3,6 @@
 
 .m-dash-filters {
   > .region {
-    height: rem(45);
     padding: rem(12) 0;
     border-bottom: 1px solid $color-7;
 

--- a/src/components/Filters/index.js
+++ b/src/components/Filters/index.js
@@ -115,6 +115,7 @@ class FiltersView extends Backbone.View {
 
         if(!value) {
           select.options[0].selected = true;
+          $(select).trigger('change.select2');
         } else {
           let found = false;
           for(let i = 0, j = select.options.length; i < j; i++) {

--- a/src/components/Filters/index.js
+++ b/src/components/Filters/index.js
@@ -261,10 +261,10 @@ class FiltersView extends Backbone.View {
       serializedFilters.to = new Date(`${serializedFilters['to-year']}-${utils.pad(serializedFilters['to-month'], 2, '0')}-${utils.pad(serializedFilters['to-day'], 2, '0')}`);
     }
 
-    /* We need to silently clear the model to remove the properties "from" and
-     * "to" which aren't present in the object serializedFilters as they are
-     * virtual */
-    this.status.clear({ silent: true });
+    /* We need to silently remove the properties "from" and "to" which aren't
+     * present in the object serializedFilters as they are virtual */
+    this.status.unset('from', { silent: true });
+    this.status.unset('to', { silent: true });
 
     this.status.set(serializedFilters, { validate: true });
   }
@@ -365,10 +365,10 @@ class FiltersView extends Backbone.View {
         for(let i = 0; i < validationError.fields.length; i++) {
           if(!!~name.indexOf(validationError.fields[i])) {
             return true;
-          } 
+          }
         }
       });
-      
+
       for(let i = 0, j = invalidInputs.length; i < j; i++) {
         invalidSelects[i].classList.add('-invalid');
       }

--- a/src/components/Map/TileLayer.js
+++ b/src/components/Map/TileLayer.js
@@ -13,12 +13,12 @@ const optionalStatements = {
   donations: {
     from:    (filters, timelineDate, layer) => filters && filters.from ? `date > '${moment.utc(filters.from).format('MM-DD-YYYY')}'::date` : `date > '${moment.utc(layer.domain[0], 'YYYY-MM-DD').format('MM-DD-YYYY')}'::date`,
     to:      (filters, timelineDate) => `date < '${moment.utc(timelineDate || filters && filters.to).format('MM-DD-YYYY')}'::date`,
-    region:  filters => filters && filters.region ? `countries @> ARRAY['${filters.region}']` : '',
+    region:  filters => filters && filters.region ? `countries @> ARRAY[${filters.region.replace(/(\[|\])/g, '').split(',').map(region => `'${region}'`)}]` : '',
     sectors: filters => filters && filters.sectors.length ? `sectors && ARRAY[${filters.sectors.map(sector => `'${sector}'`).join(', ')}]` : ''
   },
   projects: {
     to:      (filters, timelineDate) => `year='${moment.utc(timelineDate || filters && filters.to).format('YYYY')}'`,
-    region:  filters => filters && filters.region ? `iso in ('${filters.region}')` : '',
+    region:  filters => filters && filters.region ? `iso in (${filters.region.replace(/(\[|\])/g, '').split(',').map(region => `'${region}'`)})` : '',
     sectors: filters => filters && filters.sectors.length ? `(${filters.sectors.map(sector => `${sector}_people<>0`).join(' OR ')})` : ''
   }
 };

--- a/src/components/Map/TileLayer.js
+++ b/src/components/Map/TileLayer.js
@@ -13,7 +13,7 @@ const optionalStatements = {
   donations: {
     from:    (filters, timelineDate, layer) => filters && filters.from ? `date > '${moment.utc(filters.from).format('MM-DD-YYYY')}'::date` : `date > '${moment.utc(layer.domain[0], 'YYYY-MM-DD').format('MM-DD-YYYY')}'::date`,
     to:      (filters, timelineDate) => `date < '${moment.utc(timelineDate || filters && filters.to).format('MM-DD-YYYY')}'::date`,
-    region:  filters => filters && filters.region ? `countries @> '%${filters.region}%'` : '',
+    region:  filters => filters && filters.region ? `countries @> ARRAY['${filters.region}']` : '',
     sectors: filters => filters && filters.sectors.length ? `sectors && ARRAY[${filters.sectors.map(sector => `'${sector}'`).join(', ')}]` : ''
   },
   projects: {

--- a/src/components/Map/TorqueLayer.js
+++ b/src/components/Map/TorqueLayer.js
@@ -45,7 +45,7 @@ const optionalStatements = {
   donations: {
     from:    (filters, range) => `date > '${range[0].format('MM-DD-YYYY')}'::date`,
     to:      (filters, range) => `date < '${range[1].format('MM-DD-YYYY')}'::date`,
-    region:  filters => filters && filters.region ? `countries @> ARRAY['${filters.region}']` : '',
+    region:  filters => filters && filters.region ? `countries @> ARRAY[${filters.region.replace(/(\[|\])/g, '').split(',').map(region => `'${region}'`)}]` : '',
     sectors: filters => filters && filters.sectors.length ? `sectors && ARRAY[${filters.sectors.map(sector => `'${sector}'`).join(', ')}]` : ''
   }
 };
@@ -113,13 +113,12 @@ class TorqueLayer {
     return this.options.sql_template.replace('$WHERE', () => {
       if(filters) {
         const res = Object.keys(statements).map(name => {
-          const filter = filters[name];
-            return statements[name](filters, [
-              moment.utc(this.state.layer.domain[0], 'YYYY-MM-DD'),
-              moment.utc(this.state.layer.domain[1], 'YYYY-MM-DD')
-            ]);
-          }).filter(statement => !!statement)
-            .join(' AND ');
+          return statements[name](filters, [
+            moment.utc(this.state.layer.domain[0], 'YYYY-MM-DD'),
+            moment.utc(this.state.layer.domain[1], 'YYYY-MM-DD')
+          ]);
+        }).filter(statement => !!statement)
+          .join(' AND ');
 
         if(res.length) {
           return (this.options.category === 'donations' ? 'WHERE ' : 'AND ') + res;

--- a/src/components/Map/TorqueLayer.js
+++ b/src/components/Map/TorqueLayer.js
@@ -45,7 +45,7 @@ const optionalStatements = {
   donations: {
     from:    (filters, range) => `date > '${range[0].format('MM-DD-YYYY')}'::date`,
     to:      (filters, range) => `date < '${range[1].format('MM-DD-YYYY')}'::date`,
-    region:  filters => filters && filters.region ? `countries @> '%${filters.region}%'` : '',
+    region:  filters => filters && filters.region ? `countries @> ARRAY['${filters.region}']` : '',
     sectors: filters => filters && filters.sectors.length ? `sectors && ARRAY[${filters.sectors.map(sector => `'${sector}'`).join(', ')}]` : ''
   }
 };
@@ -142,6 +142,14 @@ class TorqueLayer {
 
   isReady() {
     return !Number.isNaN(this.layer.timeToStep(new Date()));
+  }
+
+  /* Return true if the layer displays data */
+  hasData() {
+    /* This is a hack: in case CartoDB doesn't return any data, there's no step
+     * so start === end === 0 */
+    return !(this.layer.animator._defaultStepsRange.start === this.layer.animator._defaultStepsRange.end &&
+      this.layer.animator._defaultStepsRange.start === 0);
   }
 
 }

--- a/src/index.html
+++ b/src/index.html
@@ -145,7 +145,7 @@
     <div id="app"></div>
 
     <script src='https://api.tiles.mapbox.com/mapbox.js/v2.2.4/mapbox.js'></script>
-    <script src="https://cdn.rawgit.com/CartoDB/torque/master/dist/torque.full.js"></script>
+    <script src="https://cdn.rawgit.com/CartoDB/torque/master/dist/torque.full.uncompressed.js"></script>
     <script src="bundle.js"></script>
 
   </body>

--- a/src/scripts/models/filtersModel.js
+++ b/src/scripts/models/filtersModel.js
@@ -7,6 +7,12 @@ import moment from 'moment';
 
 class FiltersModel extends Backbone.Model {
 
+  /* We extend the default set method to add a timestamp */
+  set(key, val, options) {
+    this._timestamp = +(new Date());
+    super.set(key, val, options);
+  }
+
   validate(data) {
     let isValid = true;
     const res = {


### PR DESCRIPTION
This PR fixes two visual flaws regarding the region filter:
- The name of the region could overlap the summary part of the dashboard if it's long (for example "Caucasus (Georgia, Armenia, Azerbaijan)").
- Clearing the region filter from the dashboard wouldn't remove it from the modal filters even if the app would take the removal into account.

It should be merged after PR #105 and #106.
