### PR TITLE
Reducing extra API calls when dragging map. 

### DIFF
--- a/src/components/Dashboard/DashSummary.js
+++ b/src/components/Dashboard/DashSummary.js
@@ -42,7 +42,6 @@ class DashSummary extends React.Component {
     const endDate = nextProps.timelineDate || nextProps.filters && nextProps.filters.to;
     const sectors = nextProps.filters && nextProps.filters.sectors || [];
     const region = nextProps.filters && nextProps.filters.region;
-
     if(this.state.startDate !== startDate || this.state.endDate !== endDate ||
       !this.state.sectors && sectors ||
       this.state.sectors.toString() !== sectors.toString() ||

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -30,6 +30,19 @@ class Dashboard extends React.Component {
     this.setState({ dashboardOpen: !this.state.dashboardOpen })
   }
 
+  shouldComponentUpdate(nextProps) {
+    if (this.props.donation !== nextProps.donation ||
+      this.props.currentMode !== nextProps.currentMode ||
+      this.props.layer !== nextProps.layer ||
+      this.props.filters !== nextProps.filters ||
+      this.props.sectors !== nextProps.sectors ||
+      this.props.timelineDate !== nextProps.timelineDate ) {
+      return true;
+    }
+
+    return false;
+  }
+
   render() {
     let tabsMobile;
     let tabsDesktop;


### PR DESCRIPTION
This PR fixes the issue where many API calls where send when dragging map. 
The issue was due to "extra renders" when updating App state.
To avoid this problem, I updated the "shouldComponentUpdate" method to only allow the dashboard render when determinate properties change.

https://www.pivotaltracker.com/story/show/119192899
