### PR TITLE
"apply" and "clear" filters buttons always available

### DIFF
--- a/src/components/Filters/index.js
+++ b/src/components/Filters/index.js
@@ -245,7 +245,6 @@ class FiltersView extends Backbone.View {
         break;
       }
     }
-    this.toggleButtonsAvailability(!empty);
   }
 
   /* Update the status model with the serialized form */
@@ -268,18 +267,6 @@ class FiltersView extends Backbone.View {
     this.status.unset('to', { silent: true });
 
     this.status.set(serializedFilters, { validate: true });
-  }
-
-  /* Toggle the availability of the buttons, force it to the "visible" value if
-   * present */
-  toggleButtonsAvailability(...visible) {
-    if(!visible.length) {
-      this.applyButton.classList.toggle('is-disabled');
-      this.clearButton.classList.toggle('is-disabled');
-    } else {
-      this.applyButton.classList.toggle('is-disabled', !visible[0]);
-      this.clearButton.classList.toggle('is-disabled', !visible[0]);
-    }
   }
 
   /* Return the serialized form */
@@ -388,7 +375,6 @@ class FiltersView extends Backbone.View {
   onClear(e) {
     e.preventDefault();
     this.resetFilters();
-    this.toggleButtonsAvailability(false);
   }
 
   onDateChange(e) {

--- a/src/components/ModalFilters/index.js
+++ b/src/components/ModalFilters/index.js
@@ -139,8 +139,8 @@ class ModalFilters extends Modal {
         </fieldset>
       </div>
       <div className="buttons">
-        <button type="button" className="btn btn-primary js-apply is-disabled">Apply filters</button>
-        <button type="button" className="btn btn-third js-clear is-disabled">Clear filters</button>
+        <button type="button" className="btn btn-primary js-apply">Apply filters</button>
+        <button type="button" className="btn btn-third js-clear">Clear filters</button>
       </div>
     </div>;
   }


### PR DESCRIPTION
This PR allows "clear" and "apply" buttons always being active at filters panel.

https://www.pivotaltracker.com/story/show/119717645
