### PR TITLE
No data show in 2011 project filter when timeline played

### DIFF
--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -177,7 +177,6 @@ class MapView extends Backbone.View {
     /* We make sure that we don't ask for data outside the domain */
     if(state.timelineDate && state.layer) {
       const domain = state.layer.domain.map(date => moment.utc(date, 'YYYY-MM-DD').toDate());
-      if(+state.timelineDate < +domain[0]) state.timelineDate = domain[0];
       if(+state.timelineDate > +domain[1]) state.timelineDate = domain[1];
     }
 


### PR DESCRIPTION
Sets the first layer to the filter startDate selected and not to the domain startDate, updating the layer depending on the owned data.
