### PR TITLE
removed subtract one day to timeline domain to avoid draw invalid dates when aplying filters

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -260,6 +260,7 @@ class App extends React.Component {
     interval.unit = d3.time[interval.unit];
 
     let domain = layer.domain.map(date => moment.utc(date).toDate());
+    console.log('updateTimeline', domain)
     let filters = filtersModel.toJSON();
     if(filters.from && filters.to) {
       domain = [ filters.from, filters.to ];

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -260,7 +260,6 @@ class App extends React.Component {
     interval.unit = d3.time[interval.unit];
 
     let domain = layer.domain.map(date => moment.utc(date).toDate());
-    console.log('updateTimeline', domain)
     let filters = filtersModel.toJSON();
     if(filters.from && filters.to) {
       domain = [ filters.from, filters.to ];

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -78,10 +78,10 @@ class TimelineView extends Backbone.View {
       - svgPadding.bottom;
 
     /* Because d3 doesn't display the first tick, we subtract 1 day to it.
+     ** I removed this solution because it was showing 31-12-2010, that is not an existing date when aplying filters and it draws final points anyway.
      * NOTE: concat and clone are used to not modify the original array */
     const domain = this.options.domain.concat([]);
-    domain[0] = moment.utc(domain[0]).clone().subtract(1, 'days').toDate();
-
+    domain[0] = moment.utc(domain[0]).clone().toDate();
     /* We force the cursor to be within the domain */
     if(+this.cursorPosition > +this.options.domain[1]) this.cursorPosition = this.options.domain[1];
     if(+this.cursorPosition < +this.options.domain[0]) this.cursorPosition = this.options.domain[0];


### PR DESCRIPTION
this PR fixed an issue we found when applying date filters.
When selecting first day of the range (1-1-2011), we saw 31-12-2012 at the timeline instead. 

Finally, only removing the "subtract one day" to domain was enough because it still drawing the the first and last tick when needed (note that we are not always showing a tick, but only when a date is selected by the user or when it matches a year. )
