### PR TITLE
Bug/map query date

### DIFF
--- a/src/components/Map/TileLayer.js
+++ b/src/components/Map/TileLayer.js
@@ -11,8 +11,8 @@ const defaults = {
 
 const optionalStatements = {
   donations: {
-    from:    (filters, timelineDate, layer) => filters && filters.from ? `date > '${moment.utc(filters.from).format('MM-DD-YYYY')}'::date` : `date > '${moment.utc(layer.domain[0], 'YYYY-MM-DD').format('MM-DD-YYYY')}'::date`,
-    to:      (filters, timelineDate) => `date < '${moment.utc(timelineDate || filters && filters.to).format('MM-DD-YYYY')}'::date`,
+    from:    (filters, timelineDate, layer) => filters && filters.from ? `date >= '${moment.utc(filters.from).format('MM-DD-YYYY')}'::date` : `date >= '${moment.utc(layer.domain[0], 'YYYY-MM-DD').format('MM-DD-YYYY')}'::date`,
+    to:      (filters, timelineDate) => `date <= '${moment.utc(timelineDate || filters && filters.to).format('MM-DD-YYYY')}'::date`,
     region:  filters => filters && filters.region ? `countries @> ARRAY[${filters.region.replace(/(\[|\])/g, '').split(',').map(region => `'${region}'`)}]` : '',
     sectors: filters => filters && filters.sectors.length ? `sectors && ARRAY[${filters.sectors.map(sector => `'${sector}'`).join(', ')}]` : ''
   },

--- a/src/components/Map/TorqueLayer.js
+++ b/src/components/Map/TorqueLayer.js
@@ -43,8 +43,8 @@ const stepsRange = function(start, end) {
 
 const optionalStatements = {
   donations: {
-    from:    (filters, range) => `date > '${range[0].format('MM-DD-YYYY')}'::date`,
-    to:      (filters, range) => `date < '${range[1].format('MM-DD-YYYY')}'::date`,
+    from:    (filters, range) => `date >= '${range[0].format('MM-DD-YYYY')}'::date`,
+    to:      (filters, range) => `date <= '${range[1].format('MM-DD-YYYY')}'::date`,
     region:  filters => filters && filters.region ? `countries @> ARRAY[${filters.region.replace(/(\[|\])/g, '').split(',').map(region => `'${region}'`)}]` : '',
     sectors: filters => filters && filters.sectors.length ? `sectors && ARRAY[${filters.sectors.map(sector => `'${sector}'`).join(', ')}]` : ''
   }

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -236,8 +236,9 @@ class MapView extends Backbone.View {
 };
 
 MapView.prototype.updateLayer = (function() {
-
-  const _addLayer = _.throttle(function() {
+  /* We can't use throttle here because we wanna be sure that the last call is
+   * going to be painted */
+  const _addLayer = _.debounce(function() {
     this._removeCurrentLayer();
     this._addLayer();
   }, 200);

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -379,10 +379,13 @@ class TimelineView extends Backbone.View {
 };
 
 TimelineView.prototype.triggerDate = (function() {
-
+  /* Do note pass true as third argument (immediate argument) otherwise the
+   * trigger will be done on the leading edge instead of the trailing edge. This
+   * implies that when moving really fast the cursor we'll still trigger its
+   * last position. */
   const trigger = _.debounce(function(date) {
     this.options.triggerDate(date);
-  }, 100, true);
+  }, 100);
 
   return function() {
     if(this.currentDataIndex < 0) {


### PR DESCRIPTION
This PR fixes three issues related to the date of the layer shown on the map:
- the timeline triggered a date which may not correspond the the last position of the cursor
- the map wouldn't inclusively filter the layers by date on the contrary of the dashboard and the tooltips
- the map could show a layer which didn't reflect the last triggered date (i.e. the date in the dashboard)
