### PR TITLE
Feature/donations time aggregation

### DIFF
--- a/src/components/Map/SVGLayer.js
+++ b/src/components/Map/SVGLayer.js
@@ -174,20 +174,18 @@ class CreateTileLayer {
     const templateYear = _.indexOf(this.options.sql_template.split(' '), '$YEAR') >= 0 ? true : false;
     if (templateWhere) {
       return this.options.sql_template.replace(/\$WHERE/g, () => {
-        if(filters || timelineDate) {
-          const res = Object.keys(statements).map(name => {
-            const filter = filters[name];
-              if(Array.isArray(filter) && filter.length ||
-                !Array.isArray(filter) && filter || timelineDate) {
-                return statements[name](filters, timelineDate, layer);
-              }
-              return null;
-            }).filter(statement => !!statement)
-              .join(' AND ');
+        const res = Object.keys(statements).map(name => {
+          const filter = filters[name];
+            if(Array.isArray(filter) && filter.length ||
+              !Array.isArray(filter) && filter || timelineDate) {
+              return statements[name](filters, timelineDate, layer);
+            }
+            return null;
+          }).filter(statement => !!statement)
+            .join(' AND ');
 
-          if(res.length) {
-            return (this.options.category === 'donations' ? 'WHERE ' : 'AND ') + res;
-          }
+        if(res.length) {
+          return (this.options.category === 'donations' ? 'WHERE ' : 'AND ') + res;
         }
         return '';
       });

--- a/src/components/Map/SVGLayer.js
+++ b/src/components/Map/SVGLayer.js
@@ -65,7 +65,8 @@ class CreateTileLayer {
     }).done(topoJSON => {
       this.layer = new L.TopoJSON({
         topoJSON,
-        update: this.updateGeometry.bind(this)
+        update: this.updateGeometry.bind(this),
+        defaultFillColor: this._getDefaultGeoColor()
       });
 
       this.fetchData();
@@ -119,6 +120,16 @@ class CreateTileLayer {
       fillColor: this.options.geo_cartocss[index].color,
       fillOpacity:this.options.geo_cartocss[index].opacity
     };
+  }
+
+  /**
+   * Return the default color of the geometries when created. It uses the first
+   * color of the cartocss (supposedly the lightest) in order to provide a
+   * smooth animation to the color.
+   * @return {String} CSS color
+   */
+  _getDefaultGeoColor() {
+    return this.options.geo_cartocss[0].color;
   }
 
   /**

--- a/src/components/Map/SVGLayer.js
+++ b/src/components/Map/SVGLayer.js
@@ -12,7 +12,7 @@ const defaults = {
 
 const optionalStatements = {
   donations: {
-    from:    (filters, timelineDate, layer) => filters && filters.from ? `date >= '${moment.utc(filters.from).format('MM-DD-YYYY')}'::date` : `date >= '${moment.utc(layer.domain[0], 'YYYY-MM-DD').format('MM-DD-YYYY')}'::date`,
+    from:    (filters, timelineDate, layer) => `date >= '${timelineDate ? moment.utc(timelineDate).subtract(7, 'days').format('MM-DD-YYYY') : moment.utc(filters && filters.from ? filters.from : layer.domain[0]).format('MM-DD-YYYY')}'::date`,
     to:      (filters, timelineDate) => `date <= '${moment.utc(timelineDate || filters && filters.to).format('MM-DD-YYYY')}'::date`,
     region:  filters => filters && filters.region ? `countries @> ARRAY[${filters.region.replace(/(\[|\])/g, '').split(',').map(region => `'${region}'`)}]` : '',
     sectors: filters => filters && filters.sectors.length ? `sectors && ARRAY[${filters.sectors.map(sector => `'${sector}'`).join(', ')}]` : ''

--- a/src/components/Map/TorqueLayer.js
+++ b/src/components/Map/TorqueLayer.js
@@ -112,18 +112,16 @@ class TorqueLayer {
     const filters = this.state.filters;
     const statements = optionalStatements[this.options.category]
     return this.options.sql_template.replace('$WHERE', () => {
-      if(filters) {
-        const res = Object.keys(statements).map(name => {
-          return statements[name](filters, [
-            moment.utc(this.state.layer.domain[0], 'YYYY-MM-DD'),
-            moment.utc(this.state.layer.domain[1], 'YYYY-MM-DD')
-          ]);
-        }).filter(statement => !!statement)
-          .join(' AND ');
+      const res = Object.keys(statements).map(name => {
+        return statements[name](filters, [
+          moment.utc(this.state.layer.domain[0], 'YYYY-MM-DD'),
+          moment.utc(this.state.layer.domain[1], 'YYYY-MM-DD')
+        ]);
+      }).filter(statement => !!statement)
+        .join(' AND ');
 
-        if(res.length) {
-          return (this.options.category === 'donations' ? 'WHERE ' : 'AND ') + res;
-        }
+      if(res.length) {
+        return (this.options.category === 'donations' ? 'WHERE ' : 'AND ') + res;
       }
       return '';
     });

--- a/src/components/Map/styles.postcss
+++ b/src/components/Map/styles.postcss
@@ -110,3 +110,7 @@
   /* Enable the click to go through the SVG layer to reach the map */
   pointer-events: none;
 }
+
+.topojson-geo {
+  transition: fill .3s ease-in, fill-opacity .3s ease-in;
+}

--- a/src/scripts/helpers/LTopoJSON.js
+++ b/src/scripts/helpers/LTopoJSON.js
@@ -16,27 +16,30 @@ L.TopoJSON = L.GeoJSON.extend({
     this.topoJSON = options.topoJSON;
     this.data = options.data || {};
     this.update = options.update || this.update;
+    this.options = options;
 
     this.parseData();
-
-    this.eachLayer(function(layer) {
-      layer.setStyle({
-        fillOpacity: 0,
-        opacity: 0,
-        weight: 1
-      });
-    });
   },
 
   parseData() {
+    const geoStyles = {
+      fillOpacity: 0,
+      fillColor: this.options.defaultFillColor || undefined,
+      opacity: 0,
+      weight: 0,
+      className: 'topojson-geo'
+    };
+
     if (this.topoJSON.type.toLowerCase() === 'topology') {
       for(let key in this.topoJSON.objects) {
         const geojson = topojson.feature(this.topoJSON, this.topoJSON.objects[key]);
-        L.GeoJSON.prototype.addData.call(this, geojson);
+        this.addData(geojson);
       }
     } else {
-      L.GeoJSON.prototype.addData.call(this, this.topoJSON);
+      this.addData(this.topoJSON);
     }
+
+    this.setStyle(geoStyles);
   },
 
   /* Define the logic to update each geometry depending on the data object.

--- a/src/scripts/models/PopUpModel.js
+++ b/src/scripts/models/PopUpModel.js
@@ -9,33 +9,38 @@ class PopUpModel extends Backbone.Model {
 
   customFetch(options) {
     this.options = options;
-    return this.fetch({ url: this._getUrl(options) });
+    return this.fetch({ url: this._getUrl() });
   }
 
   _getUrl() {
-    const noFilters = filtersModel.filtersIsEmpty();
     const distributionLayerEndpoint = this.options.layer.slug === 'number-of-donors' ? '/distribution' : '';
     const refugeesEndpoint = this.options.layer.slug === 'refugee-assistance' ? '/refugees' : '';
-
     this.baseUrl = `${config.apiUrl}/${this.options.currentMode}${distributionLayerEndpoint || refugeesEndpoint }?lat=${this.options.latLng.lat}&lng=${this.options.latLng.lng}&zoom=${this.options.zoom}`;
 
-    if(this.options.timelineDate && this.options.layer) {
-      this.baseUrl = this.baseUrl + `&start_date=${moment.utc(this.options.layer.domain[0]).format('DD-MM-YYYY')}&end_date=${moment.utc(this.options.timelineDate).format('DD-MM-YYYY')}`
-    }
-
-    if (noFilters) {
-      return this.baseUrl;
-    } else {
-      return this._getUrlWithFilters();
-    }
+    return this._getUrlWithFilters();
   }
 
   _getUrlWithFilters() {
     const filters = filtersModel.toJSON();
 
-    const startDate = filters.from && `start_date = ${moment(filters.from).format('MM-DD-YYYY')}`;
+    let startDate;
+    if(this.options.currentMode === 'donations' && this.options.timelineDate) {
+      /* When the mode is donations and the layer is the SVG one (i.e.
+       * "number-of-donors"), we want the first date to be 7 days before the
+       * other one (so before the timeline date), otherwise, for the Torque
+       * layer, we want the data of the selected day. */
+      if(this.options.layer.slug === 'number-of-donors') {
+        startDate = `start_date=${moment.utc(this.options.timelineDate).subtract(7, 'days').format('DD-MM-YYYY')}`;
+      } else {
+        startDate = `start_date=${moment.utc(this.options.timelineDate).format('DD-MM-YYYY')}`;
+      }
+    }
+    else if(filters && filters.from) {
+      startDate = `start_date = ${moment.utc(filters.from).format('DD-MM-YYYY')}`;
+    }
+
     //To be coherent with what we are seeing on the map, we have to give prevalence to "timelineDate".
-    const endDate = (filters && filters.to || this.options.timelineDate) ? `endDate = ${moment.utc(this.options.timelineDate || filters && filters.to).format('MM-DD-YYYY')}` : '';
+    const endDate = `end_date = ${moment.utc(this.options.timelineDate || filters && filters.to).format('DD-MM-YYYY')}`;
     const regions = filters.region && `countries_iso=${filters['region']}`;
 
     let sectors = null;

--- a/src/scripts/models/PopUpModel.js
+++ b/src/scripts/models/PopUpModel.js
@@ -36,11 +36,11 @@ class PopUpModel extends Backbone.Model {
       }
     }
     else if(filters && filters.from) {
-      startDate = `start_date = ${moment.utc(filters.from).format('DD-MM-YYYY')}`;
+      startDate = `start_date=${moment.utc(filters.from).format('DD-MM-YYYY')}`;
     }
 
     //To be coherent with what we are seeing on the map, we have to give prevalence to "timelineDate".
-    const endDate = `end_date = ${moment.utc(this.options.timelineDate || filters && filters.to).format('DD-MM-YYYY')}`;
+    const endDate = `end_date=${moment.utc(this.options.timelineDate || filters && filters.to).format('DD-MM-YYYY')}`;
     const regions = filters.region && `countries_iso=${filters['region']}`;
 
     let sectors = null;


### PR DESCRIPTION
This PR changes the way the two donations layers fetch their data:
- the Torque layer now shows the data of the selected date
- the SVG layer shows the data of the week before the selected date (included)

It also improves the SVG layer by adding a small transition between the colors of the geometries or when they disappear.

Finally, it removes wrong lines of code present in the model of the popups which could affect the way the data were filtered by date and what international users would see on a different timezone.

@simaob Could you please see if everything's ok for you?
