### PR TITLE
Fixes an issue where an error was shown on the console

### DIFF
--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -354,7 +354,9 @@ class TimelineView extends Backbone.View {
 
     if(this.currentDataIndex) {
       /* Google Analytics */
-      const date = moment.utc(this.options.data[this.currentDataIndex].date)
+      /* If this.currentDataIndex === -1, we want to send the date of the lower
+       * domain extremity */
+      const date = moment.utc(!!~this.currentDataIndex ? this.options.data[this.currentDataIndex].date : this.options.domain[0])
         .format('MM:DD:YYYY');
       ga && ga('send', 'event', 'Timeline', 'Drag', date);
     }


### PR DESCRIPTION
This PR removes an error which used to appear in the console when the user would move the cursor to the lower extremity of the timeline on the Torque layer. It wasn't affecting the app but the analytics.
