### PR TITLE
Fixes an issue where loading the page with the SVG layer active would break the app

### DIFF
--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -303,7 +303,7 @@ MapView.prototype.updateLayer = (function() {
     if(!activeLayer) return;
 
     this.timestamp = +(new Date());
-    if(activeLayer.get('layer_type') === 'torque' &&
+    if(activeLayer.get('layer_type') === 'torque' && this.currentLayerConfig &&
       this.currentLayerConfig.layer_type === 'torque') {
 
       const filtersOldAttributes = filtersModel.previousAttributes();
@@ -320,6 +320,7 @@ MapView.prototype.updateLayer = (function() {
       }
 
     } else if(activeLayer.get('layer_type') === 'svg' &&
+      this.currentLayerConfig &&
       this.currentLayerConfig.layer_type === 'svg') {
 
       this.currentLayer.options.state = this.state.toJSON();


### PR DESCRIPTION
This PR fixes an issue where loading a URL containing a SVG layer as active would break the whole map.
