### PR TITLE
Amount donated number size smaller to avoid wrap

### DIFF
--- a/src/components/Dashboard/dash-summary-styles.postcss
+++ b/src/components/Dashboard/dash-summary-styles.postcss
@@ -44,4 +44,14 @@
   .number {
     color: $font-color-2;
   }
+
+  .number-l {
+    @media screen and (min-width: $screen-m) {
+     font-size: rem(18);
+    }
+
+    @media screen and (min-width: $screen-l) {
+     font-size: rem(20);
+    }
+  }
 }


### PR DESCRIPTION
On Ipad, 'amount donated' wraps when the number is too big. This PR avoids the text to wrap.
