### PR TITLE
Prevents the popup to go below the logo and changes the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "html-webpack-plugin": "^2.22.0",
     "http-server": "^0.9.0",
     "jquery": "^3.1.0",
-    "leaflet": "^0.7.7",
     "moment": "^2.14.1",
     "morgan": "^1.7.0",
     "normalize.css": "^4.2.0",

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -483,10 +483,10 @@ class App extends React.Component {
           </svg>
           <div className="arrow-buttons js-arrow-buttons">
             <svg className="btn arrow-button js-previous-button">
-              <path d="M7.501 0L0 9.001 7.501 18l2.98-2.481L5.05 9l5.43-6.517z" fill-rule="evenodd" />
+              <path d="M7.501 0L0 9.001 7.501 18l2.98-2.481L5.05 9l5.43-6.517z" fillRule="evenodd" />
             </svg>
             <svg className="btn arrow-button js-next-button">
-              <path d="M2.98 0l7.5 9.001L2.98 18 0 15.519 5.43 9 0 2.484z" fill-rule="evenodd" />
+              <path d="M2.98 0l7.5 9.001L2.98 18 0 15.519 5.43 9 0 2.484z" fillRule="evenodd" />
             </svg>
           </div>
           <div className="svg-container js-svg-container"></div>

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -17,9 +17,6 @@ import moment from 'moment';
 class MapView extends Backbone.View {
 
   initialize(settings) {
-    // First configure mapbox
-    L.mapbox.accessToken = config.mapboxToken;
-
     // Setting default options
     this.options = _.extend({}, this.defaults, settings.options);
 
@@ -94,6 +91,7 @@ class MapView extends Backbone.View {
       zoom: this.state.attributes.zoom,
       center: [this.state.attributes.lat, this.state.attributes.lng],
       scrollWheelZoom: false,
+      zoomControl: false,
       // minZoom: 2,
       // maxBounds: bounds,
       tileLayer: {
@@ -101,7 +99,26 @@ class MapView extends Backbone.View {
         noWrap: true,
       }
     };
-    this.map = L.mapbox.map(this.el, this.options.style, mapOptions);
+
+    this.map = new L.Map(this.el, mapOptions)
+      .setActiveArea({
+        position: 'absolute',
+        top: '100px',
+        left: '0',
+        right: '0',
+        height: 'calc(100% - 100px)'
+      });
+
+    /* We use a custom zoom control in order to change the text used for the
+     * zoom out button: "–" instead of "-" (this first one is wider on screen)
+     */
+    L.control.zoom({ zoomOutText: '–' }).addTo(this.map);
+
+    L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
+      attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+      id: this.options.style,
+      accessToken: config.mapboxToken
+    }).addTo(this.map);
 
     /* Needed for the initialization of the SVG layer */
     this.state.set({ bounds: this.map.getBounds() });

--- a/src/components/Map/layers/ClusterLayer.js
+++ b/src/components/Map/layers/ClusterLayer.js
@@ -102,6 +102,7 @@ export default class ClusterLayer {
         className: `bubble-marker -size-${bubbleSize}`,
         iconSize: bubbleSize,
         iconAnchor: [bubbleSize / 2, bubbleSize / 2],
+        popupAnchor: [0, -bubbleSize / 2],
         html: `
           <div class="bubble">
             <div class="total">${utils.numberNotation(marker.total_people)}</div>
@@ -116,7 +117,7 @@ export default class ClusterLayer {
       });
 
       return L.marker([marker.lat, marker.lng], { icon })
-        .on('click', e => this.onMarkerClick(marker, e.target._icon))
+        .on('click', e => this.onMarkerClick(marker, e.target._icon, e.target))
         .on('mouseover', e => this.onMarkerEnter(e.target._icon))
         .on('mouseout',  e => this.onMarkerLeave(e.target._icon));
     }, this));
@@ -126,8 +127,9 @@ export default class ClusterLayer {
    * Center the map to the position of the marker and zoom in until zoom 4
    * @param  {Object} marker API entity
    * @param  {Object} marker DOM element
+   * @param  {Object} marker Leaflet object
    */
-  onMarkerClick(marker, DOMMarker) {
+  onMarkerClick(marker, DOMMarker, LeafletMarker) {
     const map = this.options.map
     const zoom = map.getZoom();
     const date = this.options.state.timelineDate;
@@ -139,7 +141,7 @@ export default class ClusterLayer {
       iso: marker.iso,
       sectors: marker.per_sector,
       closeCallback: () => DOMMarker.classList.remove('-opened'),
-      className: `-offset-${popupOffset}`
+      marker: LeafletMarker
     };
 
     if(zoom <= 3) {

--- a/src/components/Map/styles.postcss
+++ b/src/components/Map/styles.postcss
@@ -45,27 +45,33 @@
     border: 0;
     background-color: transparent;
     border-radius: 0;
+    box-shadow: none;
 
     .leaflet-control-zoom-in,
     .leaflet-control-zoom-out {
       width: rem(35);
       height: rem(35);
       border: 1px solid $color-1;
+      border-radius: 0;
+      color: $orange-pumpkin;
+      font-family: $font-family-1;
+      font-size: rem(25);
+      font-weight: 400;
+      line-height: rem(35);
+      background-color: transparent;
       background-size: rem(13);
       background-position: center;
+      transition: color .3s, border-color .3s, backgroud-color .3s;
 
       &:hover {
-        background-color: $white;
+        color: $orange-tangerine;
+        border-color: $orange-tangerine;
+        background-color: rgba($color-13, .6);
       }
     }
 
     .leaflet-control-zoom-in {
-      background-image: url('../../images/plus.svg');
       margin-bottom: rem(7);
-    }
-
-    .leaflet-control-zoom-out {
-      background-image: url('../../images/minus.svg');
     }
   }
 }

--- a/src/components/PopUp/popups/AbstractPopup.js
+++ b/src/components/PopUp/popups/AbstractPopup.js
@@ -80,13 +80,28 @@ export default class AbstractPopup extends Backbone.View {
     if(isMobile) {
       this.popup = $('body').append(popupContent);
     } else {
-      this.popup = L.popup({
-          closeButton: false,
-          className: this.options && this.options.className || ''
-        })
-        .setLatLng([ this.lat, this.lng ])
-        .setContent(popupContent)
-        .openOn(this.map);
+      this.map.setView([ this.lat, this.lng ]);
+
+      /* If the popup is attached to a marker, we want it to open the marker */
+      if(this.options.marker) {
+        this.popup = L.popup({
+            closeButton: false,
+            className: this.options && this.options.className || ''
+          })
+          .setContent(popupContent);
+
+        this.options.marker
+          .bindPopup(this.popup)
+          .openPopup();
+      } else {
+        this.popup = L.popup({
+            closeButton: false,
+            className: this.options && this.options.className || ''
+          })
+          .setLatLng([ this.lat, this.lng ])
+          .setContent(popupContent)
+          .openOn(this.map);
+      }
     }
 
     (this.popup._contentNode || document.querySelector('.m-popup'))
@@ -94,8 +109,6 @@ export default class AbstractPopup extends Backbone.View {
       .addEventListener('click', () => this.close());
 
     this.setListeners(this.popup._contentNode || document.querySelector('.m-popup'));
-
-    if(!isMobile) this.map.setView([ this.lat, this.lng ]);
   }
 
   /**
@@ -109,7 +122,13 @@ export default class AbstractPopup extends Backbone.View {
         document.querySelector('.m-popup').remove();
       }
     } else {
-      this.map.closePopup();
+      if(this.options.marker) {
+        this.options.marker
+          .closePopup()
+          .unbindPopup();
+      } else {
+        this.map.closePopup();
+      }
     }
 
     if(this.options.closeCallback &&

--- a/src/components/PopUp/styles.postcss
+++ b/src/components/PopUp/styles.postcss
@@ -275,14 +275,6 @@
 }
 
 .leaflet-popup {
-
-  &.-offset-25  { bottom:  calc(25px - 7px) !important; }
-  &.-offset-40  { bottom:  calc(40px - 7px) !important; }
-  &.-offset-50  { bottom:  calc(50px - 7px) !important; }
-  &.-offset-75  { bottom:  calc(75px - 7px) !important; }
-  &.-offset-65  { bottom:  calc(65px - 7px) !important; }
-  &.-offset-110 { bottom: calc(110px - 7px) !important; }
-
   @media screen and (min-width: $screen-m) {
     width: auto;
   }
@@ -297,10 +289,12 @@
   padding: 0 !important;
   width: auto !important;
   background-color: transparent;
+  margin-bottom: 0;
 }
 
+/* We use our own tip in the m-popup component */
 .leaflet-popup-tip {
-  border-top-color: transparent;
+  display: none;
 }
 
 .leaflet-popup-close-button {

--- a/src/images/minus.svg
+++ b/src/images/minus.svg
@@ -1,1 +1,0 @@
-<svg width="13" height="2" viewBox="0 0 13 2" xmlns="http://www.w3.org/2000/svg"><title>minus</title><path d="M0 2h13V0H0v2z" fill="#e77800" fill-rule="evenodd"/></svg>

--- a/src/images/plus.svg
+++ b/src/images/plus.svg
@@ -1,1 +1,0 @@
-<svg width="13" height="13" viewBox="0 0 13 13" xmlns="http://www.w3.org/2000/svg"><title>plus</title><path d="M5.5 7.5H0v-2h5.5V0h2v5.5H13v2H7.5V13h-2V7.5z" fill="#e77800" fill-rule="evenodd"/></svg>

--- a/src/index.html
+++ b/src/index.html
@@ -40,7 +40,7 @@
     <meta name="twitter:image" content="http://worldofimpact.care.org/care-map.jpg" />
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Oswald:400,300,700">
-    <link rel="stylesheet" href="https://api.tiles.mapbox.com/mapbox.js/v2.2.4/mapbox.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css">
 
     <!-- Google analytics -->
     <script>
@@ -457,7 +457,8 @@
 
     <div id="app"></div>
 
-    <script src='https://api.tiles.mapbox.com/mapbox.js/v2.2.4/mapbox.js'></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
+    <script src="https://cdn.rawgit.com/Mappy/Leaflet-active-area/a036300996c674fa496bd4e5e090df4fd3042d51/src/leaflet.activearea.js"></script>
     <script src="https://cdn.rawgit.com/CartoDB/torque/master/dist/torque.full.js"></script>
 
   </body>


### PR DESCRIPTION
This PR prevents any popup to go below the logo.

Additionally:
- it fixes a JSX error with an attribute of two SVG elements
- it improves the code to offset the popup of the cluster layer
- it removes the library Mapbox in flavor of Leaflet (lighter)
- it adds the library [leaflet-active-area](https://github.com/Mappy/Leaflet-active-area) to power the main feature (*)

(*) The library isn't available on any CDN and the NPM module is outdated (see the [issue I opened](https://github.com/Mappy/Leaflet-active-area/issues/20)). So the library is included using GitHub's CDN but by forcing the version to be the one of the [commit `a036300`](https://github.com/Mappy/Leaflet-active-area/blob/a036300996c674fa496bd4e5e090df4fd3042d51/src/leaflet.activearea.js) to make sure that when Mappy will update `master` with the version for Leaflet 1.0, the project will keep on working (we use Leaflet 0.7.7).
